### PR TITLE
Sync fork: PySide2/6 shim, audio slider fixes, session-manager layout persistence

### DIFF
--- a/rpa/api/annotation_api.py
+++ b/rpa/api/annotation_api.py
@@ -13,7 +13,7 @@ have only 1 Read-Only Annotation.
 """
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from rpa.delegate_mngr import DelegateMngr

--- a/rpa/api/color_api.py
+++ b/rpa/api/color_api.py
@@ -16,7 +16,7 @@ from rpa.delegate_mngr import DelegateMngr
 from rpa.session_state.color_corrections import \
     ColorTimer, Grade, ColorCorrection
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from typing import List, Union, Optional, Dict, Tuple

--- a/rpa/api/session_api.py
+++ b/rpa/api/session_api.py
@@ -9,7 +9,7 @@ Attrs.
 """
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from typing import List, Optional, Tuple, Union, Any

--- a/rpa/api/timeline_api.py
+++ b/rpa/api/timeline_api.py
@@ -10,7 +10,7 @@ current timeline sequence and vice versa.
 
 from typing import List, Optional, Tuple
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from rpa.delegate_mngr import DelegateMngr

--- a/rpa/api/viewport_api.py
+++ b/rpa/api/viewport_api.py
@@ -6,7 +6,7 @@ Manage viewport transforms and overlays.
 """
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from typing import List, Optional, Tuple, Dict

--- a/rpa/app/app_main_window.py
+++ b/rpa/app/app_main_window.py
@@ -11,8 +11,8 @@ import ctypes
 import platform
 
 try:
-    from PySide2 import QtWidgets
-    from PySide2.QtCore import Signal
+    from rpa.utils.qt import QtWidgets
+    from rpa.utils.qt.QtCore import Signal
 except ImportError:
     from PySide6 import QtWidgets
     from PySide6.QtCore import Signal

--- a/rpa/app/app_palette.py
+++ b/rpa/app/app_palette.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui
+from rpa.utils.qt import QtCore, QtGui
 
 
 class AppPalette(QtGui.QPalette):

--- a/rpa/app/plugin_manager/controller.py
+++ b/rpa/app/plugin_manager/controller.py
@@ -8,7 +8,7 @@ from importlib.abc import MetaPathFinder
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Union, Any
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from rpa.app.viewport_user_input_rx import ViewportUserInputRx
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from rpa.app.plugin_manager.model import Model, ConfigPath, \

--- a/rpa/app/plugin_manager/model.py
+++ b/rpa/app/plugin_manager/model.py
@@ -3,7 +3,7 @@
 from typing import Union
 from enum import Enum, auto
 from dataclasses import dataclass
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 
 @dataclass

--- a/rpa/app/plugin_manager/settings_widget/qt_compat.py
+++ b/rpa/app/plugin_manager/settings_widget/qt_compat.py
@@ -1,117 +1,30 @@
 """
-PySide2/PySide6 Compatibility Shim.
+Deprecated: use rpa.utils.qt instead.
 
-This module provides a unified import interface for Qt components,
-automatically selecting PySide6 if available, falling back to PySide2.
-
-Usage:
-    from rpa.app.plugin_manager.settings_widget.qt_compat import QWidget, Signal, Qt
+Kept as a thin re-export so existing callers keep working; new code should
+import submodules directly, e.g.:
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 """
+from rpa.utils.qt import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+    PYSIDE_VERSION,
+    QT_BINDING,
+    get_pyside_version,
+)
 
-# Attempt PySide6 first, fallback to PySide2
-try:
-    from PySide6.QtWidgets import (
-        QWidget,
-        QMainWindow,
-        QVBoxLayout,
-        QHBoxLayout,
-        QFormLayout,
-        QGridLayout,
-        QLineEdit,
-        QCheckBox,
-        QComboBox,
-        QSpinBox,
-        QDoubleSpinBox,
-        QScrollArea,
-        QTreeWidget,
-        QTreeWidgetItem,
-        QGroupBox,
-        QPushButton,
-        QLabel,
-        QColorDialog,
-        QFileDialog,
-        QFrame,
-        QSizePolicy,
-        QSplitter,
-        QStackedWidget,
-        QListWidget,
-        QListWidgetItem,
-        QApplication,
-        QStyle,
-        QHeaderView,
-        QMessageBox,
-        QStatusBar,
-    )
-    from PySide6.QtCore import (
-        Qt,
-        Signal,
-        Slot,
-        QTimer,
-        QSize,
-        QObject,
-        Property,
-    )
-    from PySide6.QtGui import (
-        QColor,
-        QIcon,
-        QFont,
-        QPalette,
-        QPixmap,
-    )
-    PYSIDE_VERSION = 6
-
-except ImportError:
-    from PySide2.QtWidgets import (
-        QWidget,
-        QMainWindow,
-        QVBoxLayout,
-        QHBoxLayout,
-        QFormLayout,
-        QGridLayout,
-        QLineEdit,
-        QCheckBox,
-        QComboBox,
-        QSpinBox,
-        QDoubleSpinBox,
-        QScrollArea,
-        QTreeWidget,
-        QTreeWidgetItem,
-        QGroupBox,
-        QPushButton,
-        QLabel,
-        QColorDialog,
-        QFileDialog,
-        QFrame,
-        QSizePolicy,
-        QSplitter,
-        QStackedWidget,
-        QListWidget,
-        QListWidgetItem,
-        QApplication,
-        QStyle,
-        QHeaderView,
-        QMessageBox,
-        QStatusBar,
-    )
-    from PySide2.QtCore import (
-        Qt,
-        Signal,
-        Slot,
-        QTimer,
-        QSize,
-        QObject,
-        Property,
-    )
-    from PySide2.QtGui import (
-        QColor,
-        QIcon,
-        QFont,
-        QPalette,
-        QPixmap,
-    )
-    PYSIDE_VERSION = 2
-
-
-def get_pyside_version() -> int:
-    """Returns the PySide version being used (2 or 6)."""
-    return PYSIDE_VERSION
+# Preserve the original flat symbol surface used by existing callers.
+from rpa.utils.qt.QtWidgets import (
+    QWidget, QMainWindow, QVBoxLayout, QHBoxLayout, QFormLayout, QGridLayout,
+    QLineEdit, QCheckBox, QComboBox, QSpinBox, QDoubleSpinBox, QScrollArea,
+    QTreeWidget, QTreeWidgetItem, QGroupBox, QPushButton, QLabel, QColorDialog,
+    QFileDialog, QFrame, QSizePolicy, QSplitter, QStackedWidget, QListWidget,
+    QListWidgetItem, QApplication, QStyle, QHeaderView, QMessageBox, QStatusBar,
+)
+from rpa.utils.qt.QtCore import (
+    Qt, Signal, Slot, QTimer, QSize, QObject, Property,
+)
+from rpa.utils.qt.QtGui import (
+    QColor, QIcon, QFont, QPalette, QPixmap,
+)

--- a/rpa/app/plugin_manager/view.py
+++ b/rpa/app/plugin_manager/view.py
@@ -1,7 +1,7 @@
 """View elements of the MainDialog are held here."""
 
 from collections import OrderedDict
-from PySide2 import QtWidgets, QtCore, QtGui
+from rpa.utils.qt import QtWidgets, QtCore, QtGui
 
 
 class NoHideTogglableMenu(QtWidgets.QMenu):
@@ -77,7 +77,7 @@ class PluginsTableView(QtWidgets.QTableView):
 
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(
-            lambda pos: self.__context_menu.exec_(self.mapToGlobal(pos))
+            lambda pos: self.__context_menu.exec(self.mapToGlobal(pos))
         )
 
     def __toggle_is_col_copyable_action(self):

--- a/rpa/app/viewport_binding_filter.py
+++ b/rpa/app/viewport_binding_filter.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except Exception:
     from PySide6 import QtCore
 

--- a/rpa/app/viewport_user_input_rx.py
+++ b/rpa/app/viewport_user_input_rx.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/app/widgets/dropdown_combobox.py
+++ b/rpa/app/widgets/dropdown_combobox.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 

--- a/rpa/app/widgets/itv_dock_widget.py
+++ b/rpa/app/widgets/itv_dock_widget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from rpa.utils.qt import QtWidgets
 
 
 class ItvDockWidget(QtWidgets.QDockWidget):

--- a/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor/views/graph_view.py
+++ b/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor/views/graph_view.py
@@ -21,14 +21,14 @@ try:
     from PySide6.QtCore import Signal, Qt, QRectF, QPointF, QLineF
     from PySide6.QtGui import QPen, QBrush, QColor, QPainter, QFont, QPainterPath
 except:
-    from PySide2.QtWidgets import (
+    from rpa.utils.qt.QtWidgets import (
         QGraphicsView, QGraphicsScene, QGraphicsItem, QGraphicsRectItem,
         QGraphicsTextItem, QGraphicsLineItem, QGraphicsEllipseItem, QWidget,
         QGraphicsPathItem, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton,
         QLabel, QToolBar
     )
-    from PySide2.QtCore import Signal, Qt, QRectF, QPointF, QLineF
-    from PySide2.QtGui import QPen, QBrush, QColor, QPainter, QFont, QPainterPath
+    from rpa.utils.qt.QtCore import Signal, Qt, QRectF, QPointF, QLineF
+    from rpa.utils.qt.QtGui import QPen, QBrush, QColor, QPainter, QFont, QPainterPath
 
 from node_graph_editor.models.graph_model import GraphModel, NodeInfo
 

--- a/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor/views/property_editor.py
+++ b/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor/views/property_editor.py
@@ -18,11 +18,11 @@ try:
     )
     from PySide6.QtCore import Signal, Qt
 except:
-    from PySide2.QtWidgets import (
+    from rpa.utils.qt.QtWidgets import (
         QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
         QScrollArea, QGroupBox, QLineEdit, QSplitter
     )
-    from PySide2.QtCore import Signal, Qt
+    from rpa.utils.qt.QtCore import Signal, Qt
 
 from node_graph_editor.models.property_model import PropertyInfo
 from node_graph_editor.views.widgets.property_widgets import PropertyWidgetFactory, PropertyWidgetBase

--- a/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor/views/widgets/property_widgets.py
+++ b/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor/views/widgets/property_widgets.py
@@ -18,11 +18,11 @@ try:
     )
     from PySide6.QtCore import Signal, Qt
 except:
-    from PySide2.QtWidgets import (
+    from rpa.utils.qt.QtWidgets import (
         QWidget, QHBoxLayout, QVBoxLayout, QLabel, QSpinBox,
         QDoubleSpinBox, QLineEdit, QPushButton, QCheckBox
     )
-    from PySide2.QtCore import Signal, Qt
+    from rpa.utils.qt.QtCore import Signal, Qt
 
 
 class PropertyWidgetBase(QWidget):

--- a/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor_mode.py
+++ b/rpa/open_rv/pkgs/node_graph_editor/node_graph_editor_mode.py
@@ -19,18 +19,9 @@ SOLID Principles Applied:
 import rv.rvtypes
 import rv.commands as rvc
 
-try:
-    import rv.qtutils
-    from PySide6.QtWidgets import QDockWidget, QSplitter, QWidget, QVBoxLayout
-    from PySide6.QtCore import Qt, QTimer
-except:
-    try:
-        import rv.qtutils
-        from PySide2.QtWidgets import QDockWidget, QSplitter, QWidget, QVBoxLayout
-        from PySide2.QtCore import Qt, QTimer
-    except:
-        print("Error: PySide2 or PySide6 required for Node Graph Editor")
-        raise
+import rv.qtutils
+from rpa.utils.qt.QtWidgets import QDockWidget, QSplitter, QWidget, QVBoxLayout
+from rpa.utils.qt.QtCore import Qt, QTimer
 
 from node_graph_editor.models import GraphModel, PropertyModel
 from node_graph_editor.views import GraphView, PropertyEditor

--- a/rpa/open_rv/pkgs/rpa_core_pkg/rpa_core_mode.py
+++ b/rpa/open_rv/pkgs/rpa_core_pkg/rpa_core_mode.py
@@ -1,7 +1,7 @@
 from rv import rvtypes
 from rpa.open_rv.rpa_core.rpa_core import RpaCore
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 

--- a/rpa/open_rv/pkgs/rpa_widgets_pkg/rpa_widgets_mode.py
+++ b/rpa/open_rv/pkgs/rpa_widgets_pkg/rpa_widgets_mode.py
@@ -1,8 +1,8 @@
 import os
 try:
-    from PySide2 import QtCore, QtWidgets
-    from PySide2.QtWidgets import QAction
-    from PySide2.QtGui import QKeySequence
+    from rpa.utils.qt import QtCore, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
+    from rpa.utils.qt.QtGui import QKeySequence
 except:
     from PySide6 import QtCore, QtWidgets
     from PySide6.QtGui import QAction, QKeySequence

--- a/rpa/open_rv/rpa_core/api/annotation_api_core.py
+++ b/rpa/open_rv/rpa_core/api/annotation_api_core.py
@@ -2,7 +2,7 @@ import math
 import time
 from collections import deque
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from OpenGL import GL

--- a/rpa/open_rv/rpa_core/api/clip_attr_api_core/clip_attr_api_core.py
+++ b/rpa/open_rv/rpa_core/api/clip_attr_api_core/clip_attr_api_core.py
@@ -1,6 +1,6 @@
 from typing import List
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 

--- a/rpa/open_rv/rpa_core/api/color_api_core.py
+++ b/rpa/open_rv/rpa_core/api/color_api_core.py
@@ -4,7 +4,7 @@ from OpenGL import GL
 from rv import commands as rvc
 from rv import extra_commands as rve
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from rpa.open_rv.rpa_core.api.utils import app_to_rv

--- a/rpa/open_rv/rpa_core/api/session_api_core.py
+++ b/rpa/open_rv/rpa_core/api/session_api_core.py
@@ -1,6 +1,6 @@
 from rpa.session_state.session import Session
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from rv import commands, runtime, extra_commands

--- a/rpa/open_rv/rpa_core/api/timeline_api_core.py
+++ b/rpa/open_rv/rpa_core/api/timeline_api_core.py
@@ -63,9 +63,8 @@ class TimelineApiCore(QtCore.QObject):
         return self.__session.timeline.get_volume()
 
     def set_volume(self, volume):
-        volume = volume / 100.0
-        self.__session.timeline.set_volume(volume)
-        rvc.setFloatProperty("#RVSoundTrack.audio.volume", [volume])
+        self.__session.timeline.set_volume(int(volume))
+        rvc.setFloatProperty("#RVSoundTrack.audio.volume", [volume / 100.0])
         return True
 
     def set_mute(self, state):

--- a/rpa/open_rv/rpa_core/api/timeline_api_core.py
+++ b/rpa/open_rv/rpa_core/api/timeline_api_core.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from rv import runtime

--- a/rpa/open_rv/rpa_core/api/viewport_api_core.py
+++ b/rpa/open_rv/rpa_core/api/viewport_api_core.py
@@ -7,10 +7,7 @@ from dataclasses import dataclass
 import imageio.v3 as iio
 import numpy as np
 from OpenGL import GL
-try:
-    from PySide2 import QtGui, QtCore, QtWebEngineWidgets
-except:
-    from PySide6 import QtGui, QtCore, QtWebEngineWidgets
+from rpa.utils.qt import QtGui, QtCore, QtWebEngineWidgets
 from rv import commands as rvc
 from rv import extra_commands as rve
 from rv import runtime

--- a/rpa/plugins/anim_edit/anim_edit.py
+++ b/rpa/plugins/anim_edit/anim_edit.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from anim_edit.widget.frame_editor import FrameEditor
 

--- a/rpa/plugins/anim_edit/widget/frame_editor.py
+++ b/rpa/plugins/anim_edit/widget/frame_editor.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from rpa.utils.validators import NumValidator
 
 
@@ -283,7 +283,7 @@ class FrameEditor(QtWidgets.QWidget):
             "original Media Start and Media End frames."
         )
         msg_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
-        msg_box.exec_()
+        msg_box.exec()
 
     def __hold_frames(self):
         clip_id = self.__session_api.get_current_clip()

--- a/rpa/plugins/annotation/annotation.py
+++ b/rpa/plugins/annotation/annotation.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 from annotation.widget.annotation import Annotation as RpaAnnotation
 import annotation.widget.constants as C
 

--- a/rpa/plugins/annotation/widget/actions.py
+++ b/rpa/plugins/annotation/widget/actions.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtGui, QtCore
-    from PySide2.QtWidgets import QAction, QActionGroup
+    from rpa.utils.qt import QtGui, QtCore
+    from rpa.utils.qt.QtWidgets import QAction, QActionGroup
 except:
     from PySide6 import QtGui, QtCore
     from PySide6.QtGui import QAction, QActionGroup

--- a/rpa/plugins/annotation/widget/annotation.py
+++ b/rpa/plugins/annotation/widget/annotation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import json
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from annotation.widget.actions import Actions

--- a/rpa/plugins/annotation/widget/color_picker/controller.py
+++ b/rpa/plugins/annotation/widget/color_picker/controller.py
@@ -3,7 +3,7 @@ Controller for Color Picker
 """
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from annotation.widget.color_picker.model import Rgb

--- a/rpa/plugins/annotation/widget/color_picker/model.py
+++ b/rpa/plugins/annotation/widget/color_picker/model.py
@@ -4,7 +4,7 @@ Model for Color Picker
 
 from collections import deque
 try:
-    from PySide2 import QtGui
+    from rpa.utils.qt import QtGui
 except:
     from PySide6 import QtGui
 

--- a/rpa/plugins/annotation/widget/color_picker/view/color_monitor.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/color_monitor.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from annotation.widget.color_picker.model import Rgb

--- a/rpa/plugins/annotation/widget/color_picker/view/color_sliders/clearing_slider_label.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/color_sliders/clearing_slider_label.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/annotation/widget/color_picker/view/color_sliders/color_slider.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/color_sliders/color_slider.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from string import Template

--- a/rpa/plugins/annotation/widget/color_picker/view/color_sliders/color_sliders.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/color_sliders/color_sliders.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from annotation.widget.color_picker.view import qcolor

--- a/rpa/plugins/annotation/widget/color_picker/view/color_sliders/double_slider.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/color_sliders/double_slider.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/annotation/widget/color_picker/view/eye_dropper/ScreenScraper.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/eye_dropper/ScreenScraper.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from rpa_widgets.sub_widgets.color_circle import Rgb
 
 

--- a/rpa/plugins/annotation/widget/color_picker/view/eye_dropper/eye_dropper.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/eye_dropper/eye_dropper.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets, QtGui
+    from rpa.utils.qt import QtCore, QtWidgets, QtGui
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/annotation/widget/color_picker/view/palette.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/palette.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction

--- a/rpa/plugins/annotation/widget/color_picker/view/qcolor.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/qcolor.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtGui
+    from rpa.utils.qt import QtGui
 except:
     from PySide6 import QtGui
 

--- a/rpa/plugins/annotation/widget/color_picker/view/resources/resources.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/resources/resources.py
@@ -4,7 +4,7 @@
 # WARNING! All changes made in this file will be lost!
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 

--- a/rpa/plugins/annotation/widget/color_picker/view/view.py
+++ b/rpa/plugins/annotation/widget/color_picker/view/view.py
@@ -3,7 +3,7 @@ View for Color Picker
 """
 
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 

--- a/rpa/plugins/annotation/widget/resources/resources.py
+++ b/rpa/plugins/annotation/widget/resources/resources.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x02\xc8\

--- a/rpa/plugins/annotation/widget/tool_bar.py
+++ b/rpa/plugins/annotation/widget/tool_bar.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 

--- a/rpa/plugins/app_color_corrector/app_color_corrector.py
+++ b/rpa/plugins/app_color_corrector/app_color_corrector.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from app_color_corrector.widget.controller import Controller
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 

--- a/rpa/plugins/app_color_corrector/widget/controller.py
+++ b/rpa/plugins/app_color_corrector/widget/controller.py
@@ -3,7 +3,7 @@ Controller for Color Corrector
 """
 import numpy as np
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 

--- a/rpa/plugins/app_color_corrector/widget/view/clearing_slider_label.py
+++ b/rpa/plugins/app_color_corrector/widget/view/clearing_slider_label.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/app_color_corrector/widget/view/color_corrector.py
+++ b/rpa/plugins/app_color_corrector/widget/view/color_corrector.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtWidgets, QtGui, QtCore
+    from rpa.utils.qt import QtWidgets, QtGui, QtCore
 except:
     from PySide6 import QtWidgets, QtGui, QtCore
 

--- a/rpa/plugins/app_color_corrector/widget/view/color_knob.py
+++ b/rpa/plugins/app_color_corrector/widget/view/color_knob.py
@@ -1,6 +1,6 @@
 import math
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from rpa_widgets.sub_widgets import input_line_edit

--- a/rpa/plugins/app_color_corrector/widget/view/color_panel.py
+++ b/rpa/plugins/app_color_corrector/widget/view/color_panel.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from rpa_widgets.sub_widgets.color_circle import ColorCircle

--- a/rpa/plugins/app_color_corrector/widget/view/color_sliders.py
+++ b/rpa/plugins/app_color_corrector/widget/view/color_sliders.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from app_color_corrector.widget.view.clearing_slider_label import ClearingSliderLabel

--- a/rpa/plugins/app_color_corrector/widget/view/resources/resources.py
+++ b/rpa/plugins/app_color_corrector/widget/view/resources/resources.py
@@ -4,7 +4,7 @@
 # WARNING! All changes made in this file will be lost!
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 

--- a/rpa/plugins/app_color_corrector/widget/view/slider.py
+++ b/rpa/plugins/app_color_corrector/widget/view/slider.py
@@ -1,6 +1,6 @@
 import math
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from rpa_widgets.sub_widgets import input_line_edit

--- a/rpa/plugins/app_color_corrector/widget/view/tab_widget.py
+++ b/rpa/plugins/app_color_corrector/widget/view/tab_widget.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from app_color_corrector.widget.view.color_corrector import ColorCorrectionAndGrading

--- a/rpa/plugins/app_color_corrector/widget/view/view.py
+++ b/rpa/plugins/app_color_corrector/widget/view/view.py
@@ -3,7 +3,7 @@ View for Color Corrector
 """
 
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from rpa_widgets.sub_widgets.mini_label_button import MiniLabelButton

--- a/rpa/plugins/app_console_logger/app_console_logger.py
+++ b/rpa/plugins/app_console_logger/app_console_logger.py
@@ -12,7 +12,7 @@ early output to be captured.
 import sys
 import logging
 
-from PySide2 import QtCore, QtGui
+from rpa.utils.qt import QtCore, QtGui
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 
 from app_console_logger.log_bridge import (

--- a/rpa/plugins/app_console_logger/console_view.py
+++ b/rpa/plugins/app_console_logger/console_view.py
@@ -9,7 +9,7 @@ import html
 import time
 from collections import deque
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 
 
 # Categories used for filtering — match the (category, level) values

--- a/rpa/plugins/app_console_logger/log_bridge.py
+++ b/rpa/plugins/app_console_logger/log_bridge.py
@@ -6,7 +6,7 @@ GUI updates always happen on the main thread even when the originating
 print() or logger call came from a non-GUI thread.
 """
 import logging
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 
 class LogBridge(QtCore.QObject):

--- a/rpa/plugins/app_session_assistant/app_session_assistant.py
+++ b/rpa/plugins/app_session_assistant/app_session_assistant.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui
+from rpa.utils.qt import QtCore, QtGui
 from app_session_assistant.widget.session_assistant import SessionAssistant
 
 

--- a/rpa/plugins/app_session_assistant/widget/session_assistant.py
+++ b/rpa/plugins/app_session_assistant/widget/session_assistant.py
@@ -1,8 +1,8 @@
 from typing import List
 from rpa.utils import utils
 try:
-    from PySide2 import QtCore, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtWidgets
     from PySide6.QtGui import QAction

--- a/rpa/plugins/app_session_io/app_session_io.py
+++ b/rpa/plugins/app_session_io/app_session_io.py
@@ -1,6 +1,6 @@
 import os
-from PySide2 import QtCore, QtGui, QtWidgets
-from PySide2.QtWidgets import QAction
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
+from rpa.utils.qt.QtWidgets import QAction
 from rpa_widgets.session_io.session_io import SessionIO
 
 

--- a/rpa/plugins/app_session_manager/app_session_manager.py
+++ b/rpa/plugins/app_session_manager/app_session_manager.py
@@ -1,5 +1,5 @@
 import os
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from app_session_manager.widget.session_manager import SessionManager
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from dataclasses import dataclass

--- a/rpa/plugins/app_session_manager/app_session_manager.py
+++ b/rpa/plugins/app_session_manager/app_session_manager.py
@@ -42,11 +42,15 @@ class AppSessionManager(QtCore.QObject):
         self.__session_api.delegate_mngr.add_post_delegate(
             self.__session_api.set_playlist_name,
             self.__playlist_name_changed)
-        self.__main_window.destroyed.connect(
-            self.__session_manager.save_preferences)
+        self.__main_window.SIG_CLOSED.connect(self.__on_main_window_closed)
         self.__settings_api.SIG_SETTINGS_CHANGED.connect(self.__setting_changed)
 
         self.__load_preferences()
+
+    def __on_main_window_closed(self):
+        self.__session_manager.flush_pending_save()
+        self.__save_preferences()
+        self.__config_api.sync()
 
     def __setting_changed(self, setting_id:str, value: Any):
         if setting_id == f"{Pref.PLUGIN}.{Pref.CONTROL}/{Pref.CURRENT_FRAME_MODE}":

--- a/rpa/plugins/app_session_manager/widget/clips_controller/clips_controller.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/clips_controller.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtWidgets, QtGui
-    from PySide2.QtWidgets import QShortcut
+    from rpa.utils.qt import QtCore, QtWidgets, QtGui
+    from rpa.utils.qt.QtWidgets import QShortcut
 except:
     from PySide6 import QtCore, QtWidgets, QtGui
     from PySide6.QtGui import QShortcut

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/context_menu.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/context_menu.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction
@@ -142,7 +142,7 @@ class ContextMenu(QtWidgets.QMenu):
                     if new_action_id:
                         action_map[new_action_id] = action
 
-        self.exec_(pos)
+        self.exec(pos)
 
     def inject_obj(self, obj):
         self.__injected_obj = obj

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/header_view.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/header_view.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/header_view.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/header_view.py
@@ -244,8 +244,8 @@ class HeaderViewPrefCntrlr:
         return [attr_pair[0] for attr_pair in visually_sorted_columns]
 
     def set_sort_state(self, attr, order):
-        if not order:
-            order = QtCore.Qt.DescendingOrder
+        if order is None:
+            order = QtCore.Qt.AscendingOrder
 
         model_attrs = self.__source_model.attrs
         if any([not attr, attr not in model_attrs]):

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/item_delegate.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/item_delegate.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets, QtGui
+    from rpa.utils.qt import QtCore, QtWidgets, QtGui
 except:
     from PySide6 import QtCore, QtWidgets, QtGui
 

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/model.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/model.py
@@ -1,7 +1,7 @@
 import json
 from typing import Union
 try:
-    from PySide2 import QtCore, QtGui
+    from rpa.utils.qt import QtCore, QtGui
 except:
     from PySide6 import QtCore, QtGui
 import app_session_manager.widget.clips_controller.view.resources.resources

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/resources/resources.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/resources/resources.py
@@ -4,7 +4,7 @@
 # WARNING! All changes made in this file will be lost!
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/style.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/style.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/thumbnail_loader.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/thumbnail_loader.py
@@ -2,9 +2,9 @@ import time
 
 
 try:
-    from PySide2.QtCore import QObject, QUrl, QByteArray, QRect, QSize, QPoint, Qt
-    from PySide2.QtNetwork import QNetworkAccessManager, QNetworkRequest
-    from PySide2.QtGui import QImage, QPixmap, QColor, QPainter, QPolygon
+    from rpa.utils.qt.QtCore import QObject, QUrl, QByteArray, QRect, QSize, QPoint, Qt
+    from rpa.utils.qt.QtNetwork import QNetworkAccessManager, QNetworkRequest
+    from rpa.utils.qt.QtGui import QImage, QPixmap, QColor, QPainter, QPolygon
 except:
     from PySide6.QtCore import QObject, QUrl, QByteArray, QRect, QSize, QPoint, Qt
     from PySide6.QtNetwork import QNetworkAccessManager, QNetworkRequest

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/view.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/view.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets, QtGui
+    from rpa.utils.qt import QtCore, QtWidgets, QtGui
 except:
     from PySide6 import QtCore, QtWidgets, QtGui
 from app_session_manager.widget.clips_controller.view.item_delegate \
@@ -63,7 +63,7 @@ class Table(QtWidgets.QTableView):
         if not index.isValid():
             self.SIG_EMPTY_SPACE_CLICKED.emit()
 
-        if event.button() == QtCore.Qt.MidButton:
+        if event.button() == QtCore.Qt.MiddleButton:
             self.setDragEnabled(True)
         super().mousePressEvent(event)
 
@@ -107,7 +107,7 @@ class Table(QtWidgets.QTableView):
         mime_data = self.model().mimeData(self.selectionModel().selectedIndexes())
         drag.setMimeData(mime_data)
         drag.setPixmap(QtGui.QPixmap())
-        drag.exec_(supportedActions)
+        drag.exec(supportedActions)
 
 
 class View(QtWidgets.QWidget):

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/playlists_controller.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/playlists_controller.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 from app_session_manager.widget.playlists_controller.view.view \

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/view/context_menu.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/view/context_menu.py
@@ -1,7 +1,7 @@
 import os
 try:
-    from PySide2 import QtCore, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtWidgets
     from PySide6.QtGui import QAction
@@ -113,7 +113,7 @@ class ContextMenu(QtWidgets.QMenu):
                         continue
                     self.addMenu(menu)
 
-        self.exec_(pos)
+        self.exec(pos)
 
     def inject_obj(self, obj):
         self.__injected_obj = obj
@@ -149,7 +149,7 @@ class ContextMenu(QtWidgets.QMenu):
         del_action = ActionWithObj("Delete", action, menu)
         del_action.SIG_TRIGGERED.connect(self.__delete_permanently_deleted)
         menu.addAction(del_action)
-        menu.exec_(self.__restore_menu.mapToGlobal(pos))
+        menu.exec(self.__restore_menu.mapToGlobal(pos))
 
     def __delete_permanently_deleted(self, action):
         p_id = action.data()

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/view/item_delegate.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/view/item_delegate.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtWidgets, QtGui, QtCore
+    from rpa.utils.qt import QtWidgets, QtGui, QtCore
 except:
     from PySide6 import QtWidgets, QtGui, QtCore
 

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/view/model.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/view/model.py
@@ -1,7 +1,7 @@
 import json
 
 try:
-    from PySide2 import QtCore, QtGui
+    from rpa.utils.qt import QtCore, QtGui
 except:
     from PySide6 import QtCore, QtGui
 import app_session_manager.widget.playlists_controller.view.resources.resources

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/view/resources/resources.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/view/resources/resources.py
@@ -4,7 +4,7 @@
 # WARNING! All changes made in this file will be lost!
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/view/style.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/view/style.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/app_session_manager/widget/playlists_controller/view/view.py
+++ b/rpa/plugins/app_session_manager/widget/playlists_controller/view/view.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from app_session_manager.widget.playlists_controller.view.item_delegate \
@@ -121,7 +121,7 @@ class View(QtWidgets.QListView):
         self.__mime_data_formats = mime_data.formats()
         drag.setMimeData(mime_data)
         drag.setPixmap(QtGui.QPixmap())
-        drag.exec_(supportedActions)
+        drag.exec(supportedActions)
 
     def dragEnterEvent(self, event):
         mime_data = event.mimeData()

--- a/rpa/plugins/app_session_manager/widget/session_manager.py
+++ b/rpa/plugins/app_session_manager/widget/session_manager.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from app_session_manager.widget.splitter import Splitter
@@ -511,7 +511,7 @@ class SessionManager(QtCore.QObject):
                     background_color=background_color
                 )
 
-        if title_media_editor.exec_():
+        if title_media_editor.exec():
             tmp = title_media_editor.get_properties()
         else:
             tmp = {}

--- a/rpa/plugins/app_session_manager/widget/session_manager.py
+++ b/rpa/plugins/app_session_manager/widget/session_manager.py
@@ -26,14 +26,17 @@ import uuid
 class PrefKey(Enum):
     PLUGIN = "playlist_manager"
     SPLITTER_STATE = "splitter_state"
+    MAIN_WINDOW_STATE = "main_window_state"
 
 
-class SessionManager:
+class SessionManager(QtCore.QObject):
 
     def __init__(self, rpa, parent_widget):
-        super().__init__()
+        super().__init__(parent_widget)
         self.__playlists_toolbar = PlaylistsToolbar(parent_widget)
+        self.__playlists_toolbar.setObjectName("session_manager_playlists_toolbar")
         self.__clips_toolbar = ClipsToolbar(parent_widget)
+        self.__clips_toolbar.setObjectName("session_manager_clips_toolbar")
         self.__playlists_controller = PlaylistsController(rpa, parent_widget)
         self.__clips_controller = ClipsController(rpa, parent_widget)
 
@@ -109,7 +112,7 @@ class SessionManager:
         # Debounce-save preferences when UI layout changes
         self.__save_prefs_timer = QtCore.QTimer(self.__view)
         self.__save_prefs_timer.setSingleShot(True)
-        self.__save_prefs_timer.setInterval(2000)
+        self.__save_prefs_timer.setInterval(500)
         self.__save_prefs_timer.timeout.connect(self.save_preferences)
         self.__splitter.splitterMoved.connect(self.__schedule_save_preferences)
         header = self.__clips_controller.view.table.horizontalHeader()
@@ -118,6 +121,19 @@ class SessionManager:
         header.sortIndicatorChanged.connect(self.__schedule_save_preferences)
         if hasattr(header, 'SIG_COLUMN_HIDDEN'):
             header.SIG_COLUMN_HIDDEN.connect(self.__schedule_save_preferences)
+
+        self.__playlists_toolbar.topLevelChanged.connect(
+            self.__schedule_save_preferences)
+        self.__clips_toolbar.topLevelChanged.connect(
+            self.__schedule_save_preferences)
+        self.__playlists_toolbar.installEventFilter(self)
+        self.__clips_toolbar.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if obj in (self.__playlists_toolbar, self.__clips_toolbar) \
+        and event.type() == QtCore.QEvent.Move:
+            self.__schedule_save_preferences()
+        return False
 
     @property
     def view(self):
@@ -146,16 +162,28 @@ class SessionManager:
             self.__config_api.value(PrefKey.SPLITTER_STATE.value, None)
         self.__splitter.set_state(splitter_state)
 
+        main_window_state = \
+            self.__config_api.value(PrefKey.MAIN_WINDOW_STATE.value, None)
+        if main_window_state:
+            self.__view.restoreState(main_window_state)
+
         self.__config_api.endGroup()
 
     def __schedule_save_preferences(self, *args):
         self.__save_prefs_timer.start()
+
+    def flush_pending_save(self):
+        if self.__save_prefs_timer.isActive():
+            self.__save_prefs_timer.stop()
+        self.save_preferences()
 
     def save_preferences(self):
         self.__config_api.beginGroup(PrefKey.PLUGIN.value)
 
         self.__config_api.setValue(
             PrefKey.SPLITTER_STATE.value, self.__splitter.saveState())
+        self.__config_api.setValue(
+            PrefKey.MAIN_WINDOW_STATE.value, self.__view.saveState())
         self.__config_api.endGroup()
 
         self.__clips_controller.save_preferences()

--- a/rpa/plugins/app_session_manager/widget/splitter.py
+++ b/rpa/plugins/app_session_manager/widget/splitter.py
@@ -1,6 +1,6 @@
 from functools import partial
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/app_session_manager/widget/toolbars/clips_toolbar/clips_toolbar.py
+++ b/rpa/plugins/app_session_manager/widget/toolbars/clips_toolbar/clips_toolbar.py
@@ -1,8 +1,8 @@
 from typing import List, Union
 
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction

--- a/rpa/plugins/app_session_manager/widget/toolbars/icons/icons.py
+++ b/rpa/plugins/app_session_manager/widget/toolbars/icons/icons.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x03d\

--- a/rpa/plugins/app_session_manager/widget/toolbars/playlists_toolbar/playlists_toolbar.py
+++ b/rpa/plugins/app_session_manager/widget/toolbars/playlists_toolbar/playlists_toolbar.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction

--- a/rpa/plugins/background_modes/background_modes.py
+++ b/rpa/plugins/background_modes/background_modes.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets, QtGui
+from rpa.utils.qt import QtCore, QtWidgets, QtGui
 from background_modes.widget.background_modes \
     import BackgroundModes as RpaBackgroundModes
 from rpa.session_state.annotations import Annotation

--- a/rpa/plugins/background_modes/widget/actions.py
+++ b/rpa/plugins/background_modes/widget/actions.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtGui, QtCore, QtWidgets
-    from PySide2.QtWidgets import QAction, QActionGroup
+    from rpa.utils.qt import QtGui, QtCore, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction, QActionGroup
 except:
     from PySide6 import QtGui, QtCore, QtWidgets
     from PySide6.QtGui import QAction, QActionGroup

--- a/rpa/plugins/background_modes/widget/background_modes.py
+++ b/rpa/plugins/background_modes/widget/background_modes.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from background_modes.widget.actions import Actions

--- a/rpa/plugins/clips_loop_mode_toggler/clips_loop_mode_toggler.py
+++ b/rpa/plugins/clips_loop_mode_toggler/clips_loop_mode_toggler.py
@@ -1,5 +1,5 @@
-from PySide2 import QtCore, QtGui
-from PySide2.QtWidgets import QAction
+from rpa.utils.qt import QtCore, QtGui
+from rpa.utils.qt.QtWidgets import QAction
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from rpa_widgets.rpa_interpreter.rpa_interpreter import RpaInterpreter as _RpaInterpreter
 from dataclasses import dataclass, fields

--- a/rpa/plugins/color/color.py
+++ b/rpa/plugins/color/color.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 import PyOpenColorIO as OCIO
 
 import color.resources.resources

--- a/rpa/plugins/color/resources/resources.py
+++ b/rpa/plugins/color/resources/resources.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x00\xd6\

--- a/rpa/plugins/color/swizzle.py
+++ b/rpa/plugins/color/swizzle.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from rpa.utils.qt import QtCore, QtWidgets
 
 
 class ColorSwizzleDialog(QtWidgets.QDialog):

--- a/rpa/plugins/help_menu/about.py
+++ b/rpa/plugins/help_menu/about.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from rpa.utils.qt import QtCore, QtWidgets
 
 
 class AboutDialog(QtWidgets.QDialog):

--- a/rpa/plugins/help_menu/help_menu.py
+++ b/rpa/plugins/help_menu/help_menu.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets, QtGui
+from rpa.utils.qt import QtCore, QtWidgets, QtGui
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from help_menu.about import AboutDialog
 import os

--- a/rpa/plugins/help_menu/widget/about.py
+++ b/rpa/plugins/help_menu/widget/about.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from rpa.utils.qt import QtCore, QtWidgets
 
 
 class AboutDialog(QtWidgets.QDialog):

--- a/rpa/plugins/help_menu/widget/help_menu.py
+++ b/rpa/plugins/help_menu/widget/help_menu.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets, QtGui
+from rpa.utils.qt import QtCore, QtWidgets, QtGui
 from help_menu.widget.about import AboutDialog
 import os
 

--- a/rpa/plugins/hotkey_editor/hotkey_editor.py
+++ b/rpa/plugins/hotkey_editor/hotkey_editor.py
@@ -1,11 +1,11 @@
 import sys
-from PySide2.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QTreeWidget,
+from rpa.utils.qt.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QTreeWidget,
                               QTreeWidgetItem, QLineEdit, QPushButton, QLabel,
                               QHeaderView, QKeySequenceEdit, QDialog,
                               QDialogButtonBox, QMessageBox, QApplication,
                               QMainWindow, QMenuBar, QMenu, QAction, QSplitter)
-from PySide2.QtCore import Qt, Signal
-from PySide2.QtGui import QKeySequence, QFont
+from rpa.utils.qt.QtCore import Qt, Signal
+from rpa.utils.qt.QtGui import QKeySequence, QFont
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 
 
@@ -437,7 +437,7 @@ class HotkeyEditor(QWidget):
 
         dialog = HotkeyEditDialog(action_name, current_sequence, original_sequence, self)
 
-        if dialog.exec_() == QDialog.Accepted:
+        if dialog.exec() == QDialog.Accepted:
             new_sequence = dialog.get_key_sequence()
 
             # Set new shortcut

--- a/rpa/plugins/image_controller/image_controller.py
+++ b/rpa/plugins/image_controller/image_controller.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 from image_controller.widget.image_controller import ImageController as RpaImageController
 
 

--- a/rpa/plugins/image_controller/widget/actions.py
+++ b/rpa/plugins/image_controller/widget/actions.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtGui, QtCore, QtWidgets
 

--- a/rpa/plugins/image_controller/widget/image_controller.py
+++ b/rpa/plugins/image_controller/widget/image_controller.py
@@ -1,7 +1,7 @@
 import math
 
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtGui, QtCore, QtWidgets
 

--- a/rpa/plugins/image_controller/widget/resources/resources.py
+++ b/rpa/plugins/image_controller/widget/resources/resources.py
@@ -4,7 +4,7 @@
 # WARNING! All changes made in this file will be lost!
 
 try:
-    from PySide2 import QtCore
+    from rpa.utils.qt import QtCore
 except:
     from PySide6 import QtCore
 

--- a/rpa/plugins/interactive_modes/interactive_modes.py
+++ b/rpa/plugins/interactive_modes/interactive_modes.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 from interactive_modes.widget.interactive_modes import InteractiveModes as RpaInteractiveModes
 
 

--- a/rpa/plugins/interactive_modes/widget/interactive_modes.py
+++ b/rpa/plugins/interactive_modes/widget/interactive_modes.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction

--- a/rpa/plugins/interactive_modes/widget/resources/resources.py
+++ b/rpa/plugins/interactive_modes/widget/resources/resources.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x01\xad\

--- a/rpa/plugins/mask/actions.py
+++ b/rpa/plugins/mask/actions.py
@@ -1,4 +1,4 @@
-from PySide2 import QtGui, QtCore, QtWidgets
+from rpa.utils.qt import QtGui, QtCore, QtWidgets
 
 
 class Actions(QtCore.QObject):

--- a/rpa/plugins/mask/mask.py
+++ b/rpa/plugins/mask/mask.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     oiio = None
 from dataclasses import dataclass
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from mask.actions import Actions
 
 

--- a/rpa/plugins/rpa_interpreter/rpa_interpreter.py
+++ b/rpa/plugins/rpa_interpreter/rpa_interpreter.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui
+from rpa.utils.qt import QtCore, QtGui
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from rpa_widgets.rpa_interpreter.rpa_interpreter import RpaInterpreter as _RpaInterpreter
 

--- a/rpa/plugins/rpa_widgets/rpa_interpreter/rpa_interpreter.py
+++ b/rpa/plugins/rpa_widgets/rpa_interpreter/rpa_interpreter.py
@@ -1,22 +1,11 @@
-try:
-    from PySide2.QtWidgets import (
-        QWidget, QVBoxLayout, QPlainTextEdit, QTextEdit, QPushButton,
-        QLabel, QHBoxLayout, QCompleter
-    )
-    from PySide2.QtCore import Qt, QRegExp, QStringListModel
-    from PySide2.QtGui import (
-        QTextCharFormat, QFont, QColor, QSyntaxHighlighter, QKeyEvent
-    )
-except:
-    from PySide6.QtWidgets import (
-        QWidget, QVBoxLayout, QPlainTextEdit, QTextEdit, QPushButton,
-        QLabel, QHBoxLayout, QCompleter
-    )
-    from PySide6.QtCore import Qt, QRegularExpression, QStringListModel
-    QRegExp = QRegularExpression
-    from PySide6.QtGui import (
-        QTextCharFormat, QFont, QColor, QSyntaxHighlighter, QKeyEvent
-    )
+from rpa.utils.qt.QtWidgets import (
+    QWidget, QVBoxLayout, QPlainTextEdit, QTextEdit, QPushButton,
+    QLabel, QHBoxLayout, QCompleter
+)
+from rpa.utils.qt.QtCore import Qt, QRegExp, QStringListModel
+from rpa.utils.qt.QtGui import (
+    QTextCharFormat, QFont, QColor, QSyntaxHighlighter, QKeyEvent
+)
 
 import traceback
 import io

--- a/rpa/plugins/rpa_widgets/session_io/session_io.py
+++ b/rpa/plugins/rpa_widgets/session_io/session_io.py
@@ -1,7 +1,7 @@
 import os
 try:
-    from PySide2 import QtCore, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtWidgets
     from PySide6.QtGui import QAction
@@ -84,7 +84,7 @@ class SessionIO(QtCore.QObject):
         dialog = SessionIODialog(self.__main_window)
         dialog.setup(dialog_mode, self.__get_directory())
 
-        if dialog.exec_() == QtWidgets.QDialog.Accepted:
+        if dialog.exec() == QtWidgets.QDialog.Accepted:
             filepath = dialog.get_selected_filepath()
             self.__last_location = os.path.dirname(filepath)
         else:

--- a/rpa/plugins/rpa_widgets/session_io/session_io_dialog.py
+++ b/rpa/plugins/rpa_widgets/session_io/session_io_dialog.py
@@ -1,6 +1,6 @@
 import os
 try:
-    from PySide2 import QtWidgets
+    from rpa.utils.qt import QtWidgets
 except:
     from PySide6 import QtWidgets
 from rpa_widgets.session_io import constants as C

--- a/rpa/plugins/rpa_widgets/sub_widgets/color_circle.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/color_circle.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/rpa_widgets/sub_widgets/input_line_edit.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/input_line_edit.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/rpa_widgets/sub_widgets/mini_label_button.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/mini_label_button.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/rpa_widgets/sub_widgets/nonhide_menu.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/nonhide_menu.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtWidgets
+    from rpa.utils.qt import QtWidgets
 except:
     from PySide6 import QtWidgets
 

--- a/rpa/plugins/rpa_widgets/sub_widgets/slider_toolbar.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/slider_toolbar.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtGui, QtCore, QtWidgets
 import image_controller.widget.resources.resources

--- a/rpa/plugins/rpa_widgets/sub_widgets/slider_widget.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/slider_widget.py
@@ -1,7 +1,7 @@
 
 """Module for the slider."""
 try:
-    from PySide2 import QtGui, QtCore, QtWidgets
+    from rpa.utils.qt import QtGui, QtCore, QtWidgets
 except:
     from PySide6 import QtGui, QtCore, QtWidgets
 import itertools, math
@@ -750,4 +750,4 @@ if __name__ == '__main__':
 
     w.show()
     theApp.lastWindowClosed.connect(theApp.quit)
-    theApp.exec_()
+    theApp.exec()

--- a/rpa/plugins/rpa_widgets/sub_widgets/striped_frame.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/striped_frame.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtGui, QtWidgets
+    from rpa.utils.qt import QtGui, QtWidgets
 except:
     from PySide6 import QtGui, QtWidgets
 

--- a/rpa/plugins/rpa_widgets/sub_widgets/title_media_editor.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/title_media_editor.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 from dataclasses import dataclass
@@ -129,7 +129,7 @@ class TitleMediaEditor(QtWidgets.QDialog):
         self.__main_layout.addWidget(button_box)
 
     def __choose_font(self):
-        if self.__font_dialog.exec_():
+        if self.__font_dialog.exec():
             font = self.__font_dialog.get_font()
         else:
             font = None

--- a/rpa/plugins/rpa_widgets/sub_widgets/web_view.py
+++ b/rpa/plugins/rpa_widgets/sub_widgets/web_view.py
@@ -1,9 +1,6 @@
 import os
 
-try:
-    from PySide2 import QtCore, QtGui, QtNetwork, QtWebEngineCore, QtWebEngineWidgets, QtWebChannel
-except:
-    from PySide6 import QtCore, QtGui, QtNetwork, QtWebEngineCore, QtWebEngineWidgets, QtWebChannel
+from rpa.utils.qt import QtCore, QtGui, QtNetwork, QtWebEngineCore, QtWebEngineWidgets, QtWebChannel
 
 class WebView(QtWebEngineWidgets.QWebEngineView):
 

--- a/rpa/plugins/rpa_widgets/test_widgets/test_annotation_api.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_annotation_api.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from functools import partial

--- a/rpa/plugins/rpa_widgets/test_widgets/test_color_api.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_color_api.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from functools import partial

--- a/rpa/plugins/rpa_widgets/test_widgets/test_delegate_mngr.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_delegate_mngr.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from functools import partial

--- a/rpa/plugins/rpa_widgets/test_widgets/test_opengl_overlay.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_opengl_overlay.py
@@ -1,9 +1,6 @@
 import sys
 import numpy as np
-try:
-    from PySide2 import QtWidgets, QtGui, QtCore, QtOpenGL
-except:
-    from PySide2 import QtWidgets, QtGui, QtCore, QtOpenGL
+from rpa.utils.qt import QtWidgets, QtGui, QtCore, QtOpenGL
 from OpenGL.GL import *
 
 class HtmlTextureRenderer:
@@ -95,4 +92,4 @@ if __name__ == '__main__':
     win = MainWindow()
     win.setWindowTitle("Render HTML as OpenGL Texture")
     win.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/rpa/plugins/rpa_widgets/test_widgets/test_session_api.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_session_api.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from functools import partial

--- a/rpa/plugins/rpa_widgets/test_widgets/test_timeline_api.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_timeline_api.py
@@ -1,6 +1,6 @@
 import math
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from functools import partial

--- a/rpa/plugins/rpa_widgets/test_widgets/test_viewport_api.py
+++ b/rpa/plugins/rpa_widgets/test_widgets/test_viewport_api.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtWidgets
+    from rpa.utils.qt import QtCore, QtWidgets
 except:
     from PySide6 import QtCore, QtWidgets
 from functools import partial

--- a/rpa/plugins/session_auto_saver/session_auto_saver.py
+++ b/rpa/plugins/session_auto_saver/session_auto_saver.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets, QtGui
+from rpa.utils.qt import QtCore, QtWidgets, QtGui
 import os
 from rpa.app.widgets.itv_dock_widget import ItvDockWidget
 from session_auto_saver.widget.session_auto_saver import SessionAutoSaver as _SessionAutoSaver

--- a/rpa/plugins/session_auto_saver/widget/auto_save_browser.py
+++ b/rpa/plugins/session_auto_saver/widget/auto_save_browser.py
@@ -1,9 +1,9 @@
 import os
-from PySide2.QtWidgets import (
+from rpa.utils.qt.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem,
     QApplication, QDialog
 )
-from PySide2.QtCore import Qt, Signal, QDateTime
+from rpa.utils.qt.QtCore import Qt, Signal, QDateTime
 
 
 class AutoSaveBrowser(QDialog):

--- a/rpa/plugins/session_auto_saver/widget/session_auto_saver.py
+++ b/rpa/plugins/session_auto_saver/widget/session_auto_saver.py
@@ -1,7 +1,7 @@
 from typing import List
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction
@@ -188,7 +188,7 @@ class SessionAutoSaver(QtWidgets.QWidget):
                 self.__update_dont_show_auto_save_popup_pref)
             auto_save_popup.SIG_PREF_CHANGED.connect(
                 self.__update_dont_show_auto_save_popup_checkbox_state)
-            auto_save_popup.exec_()
+            auto_save_popup.exec()
             if auto_save_popup.result() == QtWidgets.QMessageBox.Yes:
                 playlist_ids = self.__rpa.session_api.get_playlists() # default playlist
                 latest_auto_save = max(auto_saves, key=os.path.getmtime)
@@ -225,10 +225,10 @@ class SessionAutoSaver(QtWidgets.QWidget):
             msg_box = _styled_msg_dialog(
                 self.__main_window, "Info",
                 "No auto saved session exists!")
-            msg_box.exec_()
+            msg_box.exec()
         else:
             self.__auto_save_browser.populate_files(self.__get_auto_saves())
-            self.__auto_save_browser.exec_()
+            self.__auto_save_browser.exec()
 
     def __get_auto_saves(self):
         autosaves = glob.glob(
@@ -254,7 +254,7 @@ class SessionAutoSaver(QtWidgets.QWidget):
             self.__main_window, "Warning",
             "Are you sure you want to replace the current session with "
             "the auto saved session?")
-        result = msg_box.exec_()
+        result = msg_box.exec()
         if result == QtWidgets.QDialog.Accepted:
             playlist_ids = self.__rpa.session_api.get_playlists() # default playlist
             success = self.__otio_reader.read_otio_file(file)

--- a/rpa/plugins/timeline/timeline.py
+++ b/rpa/plugins/timeline/timeline.py
@@ -1,5 +1,5 @@
 import os
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 from timeline.widget.timeline import TimelineController
 from dataclasses import dataclass
 from typing import Any

--- a/rpa/plugins/timeline/widget/timeline.py
+++ b/rpa/plugins/timeline/widget/timeline.py
@@ -124,7 +124,14 @@ class TimelineController(QtWidgets.QToolBar):
             self.__post_enable_audio_scrubbing)
 
         self.actions.set_play_status(*self.__timeline_api.get_playing_state())
-        self.actions.volume_slider.setValue(self.__timeline_api.get_volume())
+        self.actions.set_volume(
+            self.__timeline_api.get_volume(), emit_signal=False)
+        self.actions.toggle_mute(
+            self.__timeline_api.is_mute(), emit_signal=False)
+        self.actions.toggle_audio_scrubbing_action.blockSignals(True)
+        self.actions.toggle_audio_scrubbing_action.setChecked(
+            self.__timeline_api.is_audio_scrubbing_enabled())
+        self.actions.toggle_audio_scrubbing_action.blockSignals(False)
 
     def __step_triggered(self, step:int):
         # forward step = 1 and backward step = -1

--- a/rpa/plugins/timeline/widget/timeline.py
+++ b/rpa/plugins/timeline/widget/timeline.py
@@ -1,7 +1,7 @@
 import json
 try:
-    from PySide2 import QtCore, QtWidgets, QtGui
-    from PySide2.QtWidgets import QShortcut
+    from rpa.utils.qt import QtCore, QtWidgets, QtGui
+    from rpa.utils.qt.QtWidgets import QShortcut
 except:
     from PySide6 import QtCore, QtWidgets, QtGui
     from PySide6.QtGui import QShortcut

--- a/rpa/plugins/timeline/widget/view/actions.py
+++ b/rpa/plugins/timeline/widget/view/actions.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction, QActionGroup
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction, QActionGroup
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction, QActionGroup

--- a/rpa/plugins/timeline/widget/view/actions.py
+++ b/rpa/plugins/timeline/widget/view/actions.py
@@ -171,10 +171,13 @@ class Actions(QtCore.QObject):
         self.toggle_play_backward_action.setChecked(playing and not forward)
 
     def toggle_mute(self, checked, emit_signal=True):
-        self.blockSignals(True)
+        self.mute_checkbox.blockSignals(True)
         self.mute_checkbox.setChecked(checked)
+        self.mute_checkbox.blockSignals(False)
+        self.toggle_mute_action.blockSignals(True)
+        self.toggle_mute_action.setChecked(checked)
+        self.toggle_mute_action.blockSignals(False)
         self.update_volume_button_icon(self.volume_slider.value(), checked)
-        self.blockSignals(False)
         if emit_signal:
             self.SIG_MUTE_TOGGLED.emit(checked)
 
@@ -193,10 +196,11 @@ class Actions(QtCore.QObject):
         self.SIG_AUDIO_SCRUBBING_TOGGLED.emit(state)
 
     def set_volume(self, volume, emit_signal=True):
+        volume = int(volume)
         if self.volume_slider.value() != volume:
-            self.blockSignals(True)
+            self.volume_slider.blockSignals(True)
             self.volume_slider.setValue(volume)
-            self.blockSignals(False)
+            self.volume_slider.blockSignals(False)
         self.update_volume_button_icon(
             volume, self.mute_checkbox.isChecked())
         if emit_signal:

--- a/rpa/plugins/timeline/widget/view/line_edit.py
+++ b/rpa/plugins/timeline/widget/view/line_edit.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 

--- a/rpa/plugins/timeline/widget/view/range.py
+++ b/rpa/plugins/timeline/widget/view/range.py
@@ -1,6 +1,6 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction, QActionGroup
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction, QActionGroup
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction, QActionGroup

--- a/rpa/plugins/timeline/widget/view/slider.py
+++ b/rpa/plugins/timeline/widget/view/slider.py
@@ -2,8 +2,8 @@ import math
 import bisect
 import six
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
-    from PySide2.QtWidgets import QAction, QActionGroup
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtWidgets import QAction, QActionGroup
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
     from PySide6.QtGui import QAction, QActionGroup

--- a/rpa/plugins/transforms/actions.py
+++ b/rpa/plugins/transforms/actions.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 import transforms.resources.resources
 
 

--- a/rpa/plugins/transforms/resources/resources.py
+++ b/rpa/plugins/transforms/resources/resources.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x00\xd6\

--- a/rpa/plugins/transforms/toolbar.py
+++ b/rpa/plugins/transforms/toolbar.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from functools import partial
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from rpa.session_state.transforms import \
     TransformData, TransformType, DYNAMIC_TRANSFORM_ATTRS, STATIC_TRANSFORM_ATTRS, SCALE_ATTRS
 

--- a/rpa/plugins/transforms/transforms.py
+++ b/rpa/plugins/transforms/transforms.py
@@ -1,7 +1,7 @@
 import bisect
 import numpy as np
 from dataclasses import dataclass
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 
 from transforms.actions import Actions
 from transforms.toolbar import TransformToolBar

--- a/rpa/plugins/view_controller/actions.py
+++ b/rpa/plugins/view_controller/actions.py
@@ -1,4 +1,4 @@
-from PySide2 import QtGui, QtCore, QtWidgets
+from rpa.utils.qt import QtGui, QtCore, QtWidgets
 
 
 class Actions(QtCore.QObject):

--- a/rpa/plugins/view_controller/view_controller.py
+++ b/rpa/plugins/view_controller/view_controller.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
 from rpa_widgets.sub_widgets.slider_toolbar import SliderToolBar
 from view_controller.actions import Actions
 import math
@@ -249,13 +249,13 @@ class ViewController(QtCore.QObject):
                 self.__horizontal_lock, self.__vertical_lock)
 
         if event.type() == QtCore.QEvent.MouseButtonPress:
-            if event.button() == QtCore.Qt.MidButton and event.modifiers() == QtCore.Qt.NoModifier:
+            if event.button() == QtCore.Qt.MiddleButton and event.modifiers() == QtCore.Qt.NoModifier:
                 self.__panning_in_progress = True
                 self.__viewport_api.start_drag(get_pos())
         if self.__panning_in_progress and event.type() == QtCore.QEvent.MouseMove:
             self.__viewport_api.drag(get_pos())
         if event.type() == QtCore.QEvent.MouseButtonRelease:
-            if event.button() == QtCore.Qt.MidButton and event.modifiers() == QtCore.Qt.NoModifier:
+            if event.button() == QtCore.Qt.MiddleButton and event.modifiers() == QtCore.Qt.NoModifier:
                 self.__panning_in_progress = False
                 self.__viewport_api.end_drag()
 

--- a/rpa/session_state/timeline.py
+++ b/rpa/session_state/timeline.py
@@ -11,7 +11,7 @@ class PlayingState:
 class AudioState:
     is_mute:bool = False
     is_audio_scrubbing_enabled:bool = False
-    volume:int = 0
+    volume:int = 100
 
 
 class Timeline:

--- a/rpa/utils/qt.py
+++ b/rpa/utils/qt.py
@@ -1,0 +1,72 @@
+"""
+PySide2 / PySide6 compatibility shim.
+
+Prefers PySide6 if importable, falls back to PySide2. OpenRV exposes only the
+binding it was built against, so the fallback is effectively a binding probe.
+
+Usage (both forms work):
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt.QtCore import Qt, Signal
+
+Qt5 <-> Qt6 relocations handled here so call sites can use a single spelling:
+    - QAction, QActionGroup, QShortcut: available on BOTH QtGui and QtWidgets
+    - QRegExp (Qt6 removed): aliased to QRegularExpression on PySide6
+    - QRegExpValidator (Qt6 removed): aliased to QRegularExpressionValidator on PySide6
+"""
+import sys as _sys
+
+try:
+    from PySide6 import QtCore, QtGui, QtWidgets
+    PYSIDE_VERSION = 6
+    QT_BINDING = "PySide6"
+except ImportError:
+    from PySide2 import QtCore, QtGui, QtWidgets
+    PYSIDE_VERSION = 2
+    QT_BINDING = "PySide2"
+
+
+if PYSIDE_VERSION == 2:
+    # Qt6 moved these from QtWidgets to QtGui. Expose on QtGui too so Qt6-style
+    # imports work on PySide2.
+    QtGui.QAction = QtWidgets.QAction
+    QtGui.QActionGroup = QtWidgets.QActionGroup
+    QtGui.QShortcut = QtWidgets.QShortcut
+else:
+    # Keep Qt5-style imports working on PySide6.
+    QtWidgets.QAction = QtGui.QAction
+    QtWidgets.QActionGroup = QtGui.QActionGroup
+    QtWidgets.QShortcut = QtGui.QShortcut
+    # QRegExp / QRegExpValidator were removed in Qt6; alias to the
+    # QRegularExpression equivalents so callers written against Qt5 keep working.
+    QtCore.QRegExp = QtCore.QRegularExpression
+    QtGui.QRegExpValidator = QtGui.QRegularExpressionValidator
+
+
+# Make `from rpa.utils.qt.QtCore import X` work by registering the real
+# submodules under this package's dotted path in sys.modules.
+_sys.modules[__name__ + ".QtCore"] = QtCore
+_sys.modules[__name__ + ".QtGui"] = QtGui
+_sys.modules[__name__ + ".QtWidgets"] = QtWidgets
+
+
+def _import_optional(name):
+    try:
+        if PYSIDE_VERSION == 6:
+            mod = __import__(f"PySide6.{name}", fromlist=[name])
+        else:
+            mod = __import__(f"PySide2.{name}", fromlist=[name])
+    except ImportError:
+        return None
+    _sys.modules[__name__ + "." + name] = mod
+    return mod
+
+
+QtOpenGL = _import_optional("QtOpenGL")
+QtNetwork = _import_optional("QtNetwork")
+QtWebEngineCore = _import_optional("QtWebEngineCore")
+QtWebEngineWidgets = _import_optional("QtWebEngineWidgets")
+QtWebChannel = _import_optional("QtWebChannel")
+
+
+def get_pyside_version() -> int:
+    return PYSIDE_VERSION

--- a/rpa/utils/resources/icons.py
+++ b/rpa/utils/resources/icons.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 5.15.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide2 import QtCore
+from rpa.utils.qt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x02\xda\

--- a/rpa/utils/utils.py
+++ b/rpa/utils/utils.py
@@ -1,5 +1,5 @@
 try:
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from rpa.utils.qt import QtCore, QtGui, QtWidgets
 except:
     from PySide6 import QtCore, QtGui, QtWidgets
 import re

--- a/rpa/utils/validators.py
+++ b/rpa/utils/validators.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui
+from rpa.utils.qt import QtCore, QtGui
 
 
 class NumValidator(QtGui.QRegExpValidator):


### PR DESCRIPTION
## Summary

Three follow-up commits on top of the previously-merged `contrib/fork-sync` (PR #10):

- **4dbad6f** — Add PySide2/PySide6 compatibility shim and migrate all imports to `rpa.utils.qt`
- **dfea514** — Fix audio volume slider, mute toggle, and related UI sync
- **d4f2dca** — Persist Session Manager toolbar layout and fix sort-order preference

Local `main` was first synced with `upstream/main` (merge commit `4176dc2`) so this PR applies cleanly with no conflicts.

## Test plan

- [ ] Launch app via `rpa/launch_app` / `launch_app.bat`; verify UI loads under both PySide2 and PySide6
- [ ] Open Session Manager; adjust toolbar layout and sort order, restart, confirm the layout + sort order persist
- [ ] Toggle audio volume slider and mute; confirm state stays in sync across UI elements