### PR TITLE
Add ai_chat plugin and fix session-attr + sort-indicator bugs

### DIFF
--- a/rpa/open_rv/rpa_core/api/session_api_core.py
+++ b/rpa/open_rv/rpa_core/api/session_api_core.py
@@ -1132,7 +1132,10 @@ class SessionApiCore(QtCore.QObject):
             attr = self.__clip_attr_api.get_attr(attr_id)
             is_value_set = False
             if attr is None:
-                continue
+                # Session-only attr (e.g. "comment") — no OpenRV node-side
+                # handler. Write straight to the RPA session-state clip.
+                if attr_id in self.__session.attrs_metadata.ids:
+                    is_value_set = True
             elif self.__session.attrs_metadata.is_keyable(attr_id):
                 is_value_set = attr._set_value(clip_source_node, value)
             else:

--- a/rpa/plugins/ai_chat/ai_chat.json
+++ b/rpa/plugins/ai_chat/ai_chat.json
@@ -1,0 +1,7 @@
+{
+  "class_name": "AiChat",
+  "app_version": "1.0.0",
+  "author_email": "rpa-app-dev@imageworks.com",
+  "plugin_name": "AI Chat",
+  "description": "Natural-language chat interface that drives RPA via Claude tool-use"
+}

--- a/rpa/plugins/ai_chat/ai_chat.py
+++ b/rpa/plugins/ai_chat/ai_chat.py
@@ -1,0 +1,118 @@
+"""
+AI Chat plugin entry point.
+
+Heavily instrumented with file logging (see ``widget/_log.py``) so a failure
+inside this plugin's init can be diagnosed from
+``~/.rpa_app/ai_chat.log`` instead of disappearing into a Windows window-less
+crash.
+
+All non-trivial imports are deferred into :py:meth:`AiChat.app_init` so a bad
+import doesn't prevent the module from loading and reporting the failure.
+"""
+# Logger first; absolutely nothing else above this can fail without us
+# noticing, because the logger is the only window we have into a hung launch.
+from ai_chat.widget._log import log, log_exc, log_banner, log_path
+
+try:
+    log_banner("ai_chat module import")
+except Exception:
+    pass
+
+try:
+    from rpa.utils.qt import QtCore, QtGui  # noqa: E402
+    log("imported rpa.utils.qt OK")
+except Exception:
+    log_exc("FATAL: failed to import rpa.utils.qt")
+    raise
+
+
+class AiChat(QtCore.QObject):
+
+    def __init__(self):
+        super().__init__()
+        self.__panel = None
+        self.__dock_widget = None
+        self.__toggle_action = None
+        log("AiChat.__init__ done")
+
+    def app_init(self, rpa_app):
+        log(f"AiChat.app_init start; log file = {log_path()}")
+        try:
+            self.__rpa = rpa_app.rpa
+            self.__main_window = rpa_app.main_window
+            self.__cmd_line_args = rpa_app.cmd_line_args
+            log(f"got rpa_app fields: rpa={type(self.__rpa).__name__} "
+                f"main_window={type(self.__main_window).__name__}")
+        except Exception:
+            log_exc("FATAL: rpa_app field access failed")
+            return
+
+        try:
+            log("importing ItvDockWidget")
+            from rpa.app.widgets.itv_dock_widget import ItvDockWidget
+            log("ItvDockWidget imported OK")
+        except Exception:
+            log_exc("FATAL: ItvDockWidget import failed; plugin disabled")
+            return
+
+        try:
+            log("importing AiChatPanel")
+            from ai_chat.widget.ai_chat_panel import AiChatPanel
+            log("AiChatPanel imported OK")
+        except Exception:
+            log_exc("FATAL: AiChatPanel import failed; plugin disabled")
+            return
+
+        try:
+            log("constructing AiChatPanel")
+            self.__panel = AiChatPanel(self.__rpa, self.__main_window)
+            log("AiChatPanel constructed OK")
+        except Exception:
+            log_exc("FATAL: AiChatPanel construction failed; plugin disabled")
+            self.__panel = None
+            return
+
+        try:
+            log("constructing ItvDockWidget")
+            self.__dock_widget = ItvDockWidget("AI Chat", self.__main_window)
+            self.__dock_widget.setWidget(self.__panel)
+            log("adding dock widget to main window")
+            self.__main_window.addDockWidget(
+                QtCore.Qt.RightDockWidgetArea, self.__dock_widget)
+            self.__dock_widget.hide()
+            log("dock widget attached + hidden")
+        except Exception:
+            log_exc("FATAL: dock widget setup failed; plugin disabled")
+            return
+
+        try:
+            log("wiring toggle action + Help menu entry")
+            self.__toggle_action = self.__dock_widget.toggleViewAction()
+            self.__toggle_action.setShortcut(QtGui.QKeySequence("Shift+A"))
+            self.__toggle_action.setProperty("hotkey_editor", True)
+            help_menu = self.__main_window.get_menu("Help")
+            help_menu.addSeparator()
+            help_menu.addAction(self.__toggle_action)
+            log("Help menu entry added")
+        except Exception:
+            log_exc("non-fatal: menu wiring failed; panel still usable")
+
+        log("AiChat.app_init DONE")
+
+    def post_app_init(self):
+        log("AiChat.post_app_init start")
+        if self.__panel is None:
+            log("post_app_init: panel is None, skipping CLI overrides")
+            return
+        try:
+            api_key = getattr(self.__cmd_line_args, "anthropic_api_key", None)
+            if api_key:
+                self.__panel.set_api_key(api_key)
+                log("post_app_init: applied --anthropic-api-key")
+            model = getattr(self.__cmd_line_args, "ai_model", None)
+            if model:
+                self.__panel.set_model(model)
+                log(f"post_app_init: applied --ai-model={model}")
+        except Exception:
+            log_exc("non-fatal: post_app_init CLI override failed")
+        log("AiChat.post_app_init DONE")

--- a/rpa/plugins/ai_chat/cli_args.py
+++ b/rpa/plugins/ai_chat/cli_args.py
@@ -1,0 +1,29 @@
+"""
+CLI arg declarations for the AI Chat plugin.
+
+Imported by launch_app.py BEFORE rv.exe boots, so it must stay import-light:
+argparse only. No Qt, no rpa, no anthropic imports here.
+"""
+import argparse
+
+
+def add_cmd_line_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("AI Chat")
+    group.add_argument(
+        '--anthropic-api-key',
+        action='store',
+        type=str,
+        default=None,
+        dest='anthropic_api_key',
+        help='Anthropic API key for the AI Chat plugin. '
+             'Falls back to $ANTHROPIC_API_KEY, then to QSettings.'
+    )
+    group.add_argument(
+        '--ai-model',
+        action='store',
+        type=str,
+        default=None,
+        dest='ai_model',
+        help='Claude model id (e.g. claude-sonnet-4-6). '
+             'Falls back to QSettings, then to a built-in default.'
+    )

--- a/rpa/plugins/ai_chat/widget/_log.py
+++ b/rpa/plugins/ai_chat/widget/_log.py
@@ -1,0 +1,85 @@
+"""
+File logger for the AI Chat plugin.
+
+Writes to ``~/.rpa_app/ai_chat.log`` and also enables Python's faulthandler
+against the same file so C-level crashes (segfaults inside Qt, etc.) leave a
+trail. Every log line is flushed immediately, so a hard crash mid-init still
+yields a useful tail.
+
+Kept dependency-free (stdlib only) and importable on its own so the rest of
+the plugin can fail without breaking the logger.
+"""
+import datetime
+import faulthandler
+import os
+import sys
+import threading
+import traceback
+
+
+_LOCK = threading.Lock()
+_LOG_FILE = None
+_LOG_PATH = None
+_FAULT_FILE = None
+
+
+def _resolve_log_path() -> str:
+    base = os.path.join(os.path.expanduser("~"), ".rpa_app")
+    try:
+        os.makedirs(base, exist_ok=True)
+    except Exception:
+        # Fall back to temp if the user dir is not writable.
+        import tempfile
+        base = tempfile.gettempdir()
+    return os.path.join(base, "ai_chat.log")
+
+
+def _ensure_open():
+    global _LOG_FILE, _LOG_PATH, _FAULT_FILE
+    if _LOG_FILE is not None:
+        return
+    _LOG_PATH = _resolve_log_path()
+    # 'a' so successive launches append; rotate manually if it grows.
+    _LOG_FILE = open(_LOG_PATH, "a", encoding="utf-8", buffering=1)
+    # Separate handle for faulthandler (it needs a real fd).
+    try:
+        _FAULT_FILE = open(_LOG_PATH + ".fault", "a", encoding="utf-8",
+                           buffering=1)
+        faulthandler.enable(file=_FAULT_FILE, all_threads=True)
+    except Exception:
+        # faulthandler is best-effort; never let it block normal logging.
+        _FAULT_FILE = None
+
+
+def log_path() -> str:
+    _ensure_open()
+    return _LOG_PATH or "<unset>"
+
+
+def log(msg: str) -> None:
+    try:
+        _ensure_open()
+        ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with _LOCK:
+            _LOG_FILE.write(f"[{ts}] [pid={os.getpid()}] {msg}\n")
+            _LOG_FILE.flush()
+    except Exception:
+        # Logging must never raise.
+        pass
+
+
+def log_exc(prefix: str = "") -> None:
+    try:
+        tb = traceback.format_exc()
+    except Exception:
+        tb = "<traceback unavailable>"
+    log(f"{prefix}\n{tb}".rstrip())
+
+
+def log_banner(title: str) -> None:
+    log("=" * 60)
+    log(title)
+    log(f"python={sys.version.splitlines()[0]}")
+    log(f"executable={sys.executable}")
+    log(f"cwd={os.getcwd()}")
+    log("=" * 60)

--- a/rpa/plugins/ai_chat/widget/ai_chat_panel.py
+++ b/rpa/plugins/ai_chat/widget/ai_chat_panel.py
@@ -1,0 +1,324 @@
+"""
+Chat panel widget for the AI Chat plugin.
+
+Layout: scrollable transcript on top, input box at the bottom, action buttons
+in between. Settings (API key, model, max iterations) are persisted via
+``QSettings("imageworks.com", "rpa_app")`` under the ``ai_chat/`` group.
+"""
+import json
+import os
+
+from rpa.utils.qt import QtCore, QtGui, QtWidgets
+
+from ._log import log, log_exc
+from .chat_client import (
+    ChatClient,
+    DEFAULT_MAX_TOOL_ITERATIONS,
+    DEFAULT_MODEL,
+)
+
+
+_SETTINGS_GROUP = "ai_chat"
+
+# Curated list of Claude models the UI offers. (label, model_id) pairs.
+# Default first; ordered roughly fastest -> most capable so the dropdown is
+# easy to scan. Users can still override by typing a custom id below.
+_MODEL_OPTIONS = [
+    ("Haiku 4.5  (fastest, recommended)", "claude-haiku-4-5-20251001"),
+    ("Sonnet 4.6  (balanced)",            "claude-sonnet-4-6"),
+    ("Opus 4.7  (most capable)",          "claude-opus-4-7"),
+]
+
+
+def _load_settings():
+    s = QtCore.QSettings("imageworks.com", "rpa_app")
+    s.beginGroup(_SETTINGS_GROUP)
+    api_key = s.value("api_key", "", type=str) or ""
+    model = s.value("model", DEFAULT_MODEL, type=str) or DEFAULT_MODEL
+    max_iters = int(s.value("max_iters", DEFAULT_MAX_TOOL_ITERATIONS) or
+                    DEFAULT_MAX_TOOL_ITERATIONS)
+    s.endGroup()
+    return api_key, model, max_iters
+
+
+def _save_settings(api_key, model, max_iters):
+    s = QtCore.QSettings("imageworks.com", "rpa_app")
+    s.beginGroup(_SETTINGS_GROUP)
+    s.setValue("api_key", api_key)
+    s.setValue("model", model)
+    s.setValue("max_iters", int(max_iters))
+    s.endGroup()
+
+
+class _SettingsDialog(QtWidgets.QDialog):
+    def __init__(self, api_key, model, max_iters, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("AI Chat Settings")
+        self.setModal(True)
+
+        form = QtWidgets.QFormLayout(self)
+        self._api_key_edit = QtWidgets.QLineEdit(api_key)
+        self._api_key_edit.setEchoMode(QtWidgets.QLineEdit.Password)
+        self._api_key_edit.setPlaceholderText("sk-ant-...")
+        form.addRow("Anthropic API Key:", self._api_key_edit)
+
+        self._model_combo = QtWidgets.QComboBox()
+        for label, model_id in _MODEL_OPTIONS:
+            self._model_combo.addItem(label, model_id)
+        # Preselect the saved model. If it's not one of the known options
+        # (e.g. a custom id from QSettings), append it as an extra entry so
+        # nothing gets silently changed on the user.
+        idx = self._model_combo.findData(model)
+        if idx < 0:
+            self._model_combo.addItem(f"{model}  (custom)", model)
+            idx = self._model_combo.count() - 1
+        self._model_combo.setCurrentIndex(idx)
+        form.addRow("Model:", self._model_combo)
+
+        self._iters_spin = QtWidgets.QSpinBox()
+        self._iters_spin.setRange(1, 200)
+        self._iters_spin.setValue(int(max_iters))
+        form.addRow("Max tool iterations:", self._iters_spin)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        form.addRow(buttons)
+
+    def values(self):
+        model_id = self._model_combo.currentData() or DEFAULT_MODEL
+        return (self._api_key_edit.text().strip(),
+                model_id,
+                int(self._iters_spin.value()))
+
+
+class _Input(QtWidgets.QPlainTextEdit):
+    """Plain-text input that sends on Enter, newlines on Shift+Enter."""
+
+    SIG_SUBMIT = QtCore.Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setPlaceholderText(
+            "Ask the AI to drive RPA. "
+            "Enter to send, Shift+Enter for newline.")
+        self.setMaximumHeight(120)
+
+    def keyPressEvent(self, event):
+        if (event.key() in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter)
+                and not event.modifiers() & QtCore.Qt.ShiftModifier):
+            self.SIG_SUBMIT.emit()
+            return
+        super().keyPressEvent(event)
+
+
+class AiChatPanel(QtWidgets.QWidget):
+    def __init__(self, rpa, main_window, parent=None):
+        log("AiChatPanel.__init__ start")
+        super().__init__(parent if parent is not None else main_window)
+        self._rpa = rpa
+        self._busy = False
+
+        try:
+            api_key, model, max_iters = _load_settings()
+            log(f"settings loaded: model={model} max_iters={max_iters} "
+                f"api_key_present={bool(api_key)}")
+        except Exception:
+            log_exc("settings load failed; using defaults")
+            api_key, model, max_iters = "", DEFAULT_MODEL, DEFAULT_MAX_TOOL_ITERATIONS
+        # Env var wins over an empty stored key, so first-time launches with
+        # ANTHROPIC_API_KEY in the environment Just Work.
+        if not api_key:
+            api_key = os.environ.get("ANTHROPIC_API_KEY", "") or ""
+            log(f"using ANTHROPIC_API_KEY env: present={bool(api_key)}")
+        self._api_key = api_key
+        self._model = model
+        self._max_iters = max_iters
+
+        try:
+            log("constructing ChatClient")
+            self._client = ChatClient(
+                rpa=rpa, api_key=api_key, model=model, max_iters=max_iters,
+                parent=self)
+            log(f"ChatClient ready; tool_count={self._client.tool_count()} "
+                f"build_error={self._client.tool_build_error() or '<none>'}")
+        except Exception:
+            log_exc("FATAL: ChatClient construction failed")
+            raise
+
+        try:
+            self._client.SIG_ASSISTANT_TEXT.connect(self._on_assistant_text)
+            self._client.SIG_TOOL_CALL.connect(self._on_tool_call)
+            self._client.SIG_TOOL_RESULT.connect(self._on_tool_result)
+            self._client.SIG_DONE.connect(self._on_done)
+            self._client.SIG_ERROR.connect(self._on_error)
+            log("ChatClient signals connected")
+        except Exception:
+            log_exc("FATAL: ChatClient signal wiring failed")
+            raise
+
+        try:
+            self._build_ui()
+            log("UI built")
+        except Exception:
+            log_exc("FATAL: _build_ui failed")
+            raise
+
+        self._append_system(
+            f"AI Chat ready. {self._client.tool_count()} RPA tools loaded "
+            f"(model: {self._model}).")
+        if not api_key:
+            self._append_system(
+                "No API key configured. Open settings (⚙) to add one.")
+        log("AiChatPanel.__init__ DONE")
+
+    # ---- UI -----------------------------------------------------------
+
+    def _build_ui(self):
+        self.setMinimumSize(420, 480)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(6, 6, 6, 6)
+
+        self._transcript = QtWidgets.QTextBrowser()
+        self._transcript.setOpenExternalLinks(True)
+        self._transcript.setStyleSheet(
+            "QTextBrowser { background-color: #1e1e1e; color: #dcdcdc; "
+            "font-family: Consolas, monospace; font-size: 13px; }")
+        layout.addWidget(self._transcript, stretch=1)
+
+        self._input = _Input()
+        self._input.SIG_SUBMIT.connect(self._send)
+        layout.addWidget(self._input)
+
+        button_row = QtWidgets.QHBoxLayout()
+        self._send_btn = QtWidgets.QPushButton("Send")
+        self._send_btn.clicked.connect(self._send)
+        self._stop_btn = QtWidgets.QPushButton("Stop")
+        self._stop_btn.clicked.connect(self._client.cancel)
+        self._stop_btn.setEnabled(False)
+        self._clear_btn = QtWidgets.QPushButton("Clear")
+        self._clear_btn.clicked.connect(self._clear)
+        self._settings_btn = QtWidgets.QPushButton("⚙")
+        self._settings_btn.setToolTip("Settings")
+        self._settings_btn.setFixedWidth(32)
+        self._settings_btn.clicked.connect(self._open_settings)
+        button_row.addWidget(self._send_btn)
+        button_row.addWidget(self._stop_btn)
+        button_row.addWidget(self._clear_btn)
+        button_row.addStretch(1)
+        button_row.addWidget(self._settings_btn)
+        layout.addLayout(button_row)
+
+    # ---- Transcript helpers ------------------------------------------
+
+    @staticmethod
+    def _escape(text):
+        return (text.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                    .replace("\n", "<br>"))
+
+    def _append(self, role, body, color):
+        html = (f'<div style="margin:4px 0;">'
+                f'<span style="color:{color};font-weight:bold;">{role}</span> '
+                f'<span style="color:#dcdcdc;">{body}</span></div>')
+        self._transcript.append(html)
+
+    def _append_system(self, text):
+        self._append("system:", self._escape(text), "#888888")
+
+    def _append_user(self, text):
+        self._append("you:", self._escape(text), "#7fb8ff")
+
+    def _append_assistant(self, text):
+        self._append("ai:", self._escape(text), "#a6e22e")
+
+    def _append_tool_call(self, name, args):
+        try:
+            args_text = json.dumps(args, default=str)
+        except Exception:
+            args_text = repr(args)
+        self._append("tool ▶", self._escape(f"{name}({args_text})"),
+                     "#cccc66")
+
+    def _append_tool_result(self, name, text, is_error):
+        prefix = "tool ✖" if is_error else "tool ◀"
+        color = "#ff6666" if is_error else "#888888"
+        body = self._escape(f"{name} -> {text}")
+        self._append(prefix, body, color)
+
+    # ---- Actions ------------------------------------------------------
+
+    def _send(self):
+        if self._busy:
+            return
+        text = self._input.toPlainText().strip()
+        if not text:
+            return
+        self._input.clear()
+        self._append_user(text)
+        self._set_busy(True)
+        self._client.send(text)
+
+    def _clear(self):
+        self._transcript.clear()
+        self._client.reset()
+        self._append_system("Conversation cleared.")
+
+    def _open_settings(self):
+        dlg = _SettingsDialog(
+            self._api_key, self._model, self._max_iters, parent=self)
+        if dlg.exec() != QtWidgets.QDialog.Accepted:
+            return
+        api_key, model, max_iters = dlg.values()
+        self._api_key = api_key
+        self._model = model
+        self._max_iters = max_iters
+        _save_settings(api_key, model, max_iters)
+        self._client.set_api_key(api_key)
+        self._client.set_model(model)
+        self._append_system(
+            f"Settings updated (model: {model}, max iters: {max_iters}).")
+
+    def set_api_key(self, api_key):
+        """Public hook used by post_app_init to apply a CLI-provided key."""
+        if not api_key:
+            return
+        self._api_key = api_key
+        self._client.set_api_key(api_key)
+
+    def set_model(self, model):
+        if not model:
+            return
+        self._model = model
+        self._client.set_model(model)
+
+    # ---- Worker callbacks --------------------------------------------
+
+    def _on_assistant_text(self, text):
+        self._append_assistant(text)
+
+    def _on_tool_call(self, name, args):
+        self._append_tool_call(name, args or {})
+
+    def _on_tool_result(self, name, text, is_error):
+        self._append_tool_result(name, text, is_error)
+
+    def _on_done(self):
+        self._set_busy(False)
+
+    def _on_error(self, message):
+        self._append("error:", self._escape(message), "#ff6666")
+
+    def _set_busy(self, busy):
+        self._busy = busy
+        self._send_btn.setEnabled(not busy)
+        self._stop_btn.setEnabled(busy)
+        self._input.setReadOnly(busy)
+
+    def closeEvent(self, event):  # pragma: no cover - Qt lifecycle
+        try:
+            self._client.shutdown()
+        finally:
+            super().closeEvent(event)

--- a/rpa/plugins/ai_chat/widget/chat_client.py
+++ b/rpa/plugins/ai_chat/widget/chat_client.py
@@ -1,0 +1,358 @@
+"""
+Anthropic chat client + tool-use loop.
+
+Network calls run on a worker QThread so the UI stays responsive. Every RPA
+tool invocation is marshalled back to the main thread because RPA / Qt are
+main-thread-only. The cross-thread handoff uses a queued Qt signal that
+carries a request dict + a ``threading.Event`` the worker waits on, which
+avoids the PySide2/PySide6 incompatibilities of ``QMetaObject.invokeMethod``
+with ``Q_RETURN_ARG``.
+"""
+import threading
+
+from rpa.utils.qt import QtCore
+
+from . import tool_bridge
+from ._log import log, log_exc
+
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_MAX_TOOL_ITERATIONS = 25
+DEFAULT_MAX_TOKENS = 4096
+
+SYSTEM_PROMPT = (
+    "You are an assistant embedded in the ORI Shared Platform RPA review "
+    "application. You can drive the app by calling the provided RPA tools "
+    "(session, timeline, annotation, color, viewport). Prefer tool calls "
+    "over guessing. When the user describes intent (e.g. 'go to the next "
+    "clip', 'show me red channel only'), pick the right tool and call it. "
+    "After acting, confirm what you did in one short sentence. If a tool "
+    "returns an error, read it carefully and either retry with corrected "
+    "arguments or report the failure plainly."
+)
+
+
+class _ToolRunner(QtCore.QObject):
+    """Lives on the main thread. Worker threads request a tool call by
+    emitting :pyattr:`SIG_REQUEST` with a request dict containing
+    ``name``, ``args``, ``result`` (filled in by us), and ``event``
+    (a ``threading.Event`` we set when done)."""
+
+    SIG_REQUEST = QtCore.Signal(object)
+
+    def __init__(self, rpa, parent=None):
+        super().__init__(parent)
+        self._rpa = rpa
+        self.SIG_REQUEST.connect(self._handle, QtCore.Qt.QueuedConnection)
+
+    @QtCore.Slot(object)
+    def _handle(self, req):
+        try:
+            text = tool_bridge.call_tool(
+                self._rpa, req["name"], req["args"] or {})
+            req["result"] = {"ok": True, "text": text}
+        except Exception as exc:  # noqa: BLE001 - surface every error to LLM
+            req["result"] = {
+                "ok": False,
+                "text": f"{type(exc).__name__}: {exc}",
+            }
+        finally:
+            req["event"].set()
+
+    def run_blocking(self, name, args, timeout=120.0):
+        req = {
+            "name": name,
+            "args": args,
+            "event": threading.Event(),
+            "result": None,
+        }
+        self.SIG_REQUEST.emit(req)
+        if not req["event"].wait(timeout=timeout):
+            return {"ok": False,
+                    "text": f"Tool '{name}' timed out after {timeout}s."}
+        return req["result"]
+
+
+class _ChatWorker(QtCore.QObject):
+    """Runs the tool-use loop against the Anthropic API on a worker thread."""
+
+    SIG_ASSISTANT_TEXT = QtCore.Signal(str)
+    SIG_TOOL_CALL = QtCore.Signal(str, object)
+    SIG_TOOL_RESULT = QtCore.Signal(str, str, bool)  # name, text, is_error
+    SIG_DONE = QtCore.Signal()
+    SIG_ERROR = QtCore.Signal(str)
+
+    def __init__(self, tool_runner):
+        super().__init__()
+        self._tool_runner = tool_runner
+        self._api_key = ""
+        self._model = DEFAULT_MODEL
+        self._tools = []
+        self._system = SYSTEM_PROMPT
+        self._max_iters = DEFAULT_MAX_TOOL_ITERATIONS
+        self._messages: list = []
+        self._cancel = False
+
+    @QtCore.Slot(object)
+    def configure(self, cfg):
+        self._api_key = cfg.get("api_key", self._api_key)
+        self._model = cfg.get("model", self._model)
+        if "tools" in cfg:
+            self._tools = cfg["tools"]
+        if "max_iters" in cfg:
+            self._max_iters = int(cfg["max_iters"])
+
+    @QtCore.Slot()
+    def cancel(self):
+        self._cancel = True
+
+    @QtCore.Slot()
+    def reset(self):
+        self._messages = []
+
+    @QtCore.Slot(str)
+    def send(self, user_text):
+        self._cancel = False
+        try:
+            import anthropic  # lazy: missing dep must not break app start
+        except ImportError as exc:
+            self.SIG_ERROR.emit(
+                "anthropic SDK is not installed. Run "
+                "`python rpa/dev_setup.py install-deps` to install it. "
+                f"({exc})")
+            self.SIG_DONE.emit()
+            return
+
+        if not self._api_key:
+            self.SIG_ERROR.emit(
+                "No Anthropic API key set. Use the AI Chat settings (⚙), "
+                "the --anthropic-api-key flag, or $ANTHROPIC_API_KEY.")
+            self.SIG_DONE.emit()
+            return
+
+        try:
+            client = anthropic.Anthropic(api_key=self._api_key)
+        except Exception as exc:  # noqa: BLE001
+            self.SIG_ERROR.emit(f"Anthropic client init failed: {exc}")
+            self.SIG_DONE.emit()
+            return
+
+        self._messages.append({"role": "user", "content": user_text})
+
+        try:
+            iterations_used = 0
+            while iterations_used < self._max_iters:
+                iterations_used += 1
+                if self._cancel:
+                    break
+
+                # Prompt caching: mark the system prompt and the tool list
+                # as a cache breakpoint. Anthropic caches everything up to
+                # and including the marked block for ~5 min, billing cache
+                # hits at ~10% of normal input price and counting them only
+                # lightly against the ITPM bucket. The static system + tools
+                # blob is by far the largest part of every request, so this
+                # cuts both latency and rate-limit pressure dramatically.
+                cached_system = [{
+                    "type": "text",
+                    "text": self._system,
+                    "cache_control": {"type": "ephemeral"},
+                }]
+                cached_tools = list(self._tools)
+                if cached_tools:
+                    # Copy the last tool dict before mutating to avoid
+                    # accidentally caching cache_control into our registry.
+                    cached_tools[-1] = {
+                        **cached_tools[-1],
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                response = client.messages.create(
+                    model=self._model,
+                    max_tokens=DEFAULT_MAX_TOKENS,
+                    system=cached_system,
+                    tools=cached_tools,
+                    messages=self._messages,
+                )
+
+                try:
+                    u = response.usage
+                    log(
+                        f"usage: in={getattr(u, 'input_tokens', '?')} "
+                        f"out={getattr(u, 'output_tokens', '?')} "
+                        f"cache_create={getattr(u, 'cache_creation_input_tokens', '?')} "
+                        f"cache_read={getattr(u, 'cache_read_input_tokens', '?')} "
+                        f"stop={response.stop_reason}"
+                    )
+                except Exception:
+                    pass
+
+                assistant_blocks = []
+                for block in response.content:
+                    btype = getattr(block, "type", None)
+                    if btype == "text":
+                        text = getattr(block, "text", "") or ""
+                        if text:
+                            self.SIG_ASSISTANT_TEXT.emit(text)
+                        assistant_blocks.append(
+                            {"type": "text", "text": text})
+                    elif btype == "tool_use":
+                        assistant_blocks.append({
+                            "type": "tool_use",
+                            "id": block.id,
+                            "name": block.name,
+                            "input": block.input or {},
+                        })
+                self._messages.append(
+                    {"role": "assistant", "content": assistant_blocks})
+
+                if response.stop_reason != "tool_use":
+                    break
+
+                tool_results = []
+                for block in assistant_blocks:
+                    if block.get("type") != "tool_use":
+                        continue
+                    if self._cancel:
+                        break
+                    name = block["name"]
+                    args = block["input"] or {}
+                    self.SIG_TOOL_CALL.emit(name, dict(args))
+                    outcome = self._tool_runner.run_blocking(name, args)
+                    if not isinstance(outcome, dict):
+                        outcome = {"ok": False, "text": "<no result>"}
+                    self.SIG_TOOL_RESULT.emit(
+                        name, outcome["text"], not outcome["ok"])
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block["id"],
+                        "content": outcome["text"],
+                        "is_error": not outcome["ok"],
+                    })
+
+                if not tool_results:
+                    break
+                self._messages.append(
+                    {"role": "user", "content": tool_results})
+            else:
+                # Loop exited normally because the cap was hit (Python's
+                # while-else fires when the condition becomes false without
+                # a break).
+                pass
+
+            if iterations_used >= self._max_iters:
+                self.SIG_ERROR.emit(
+                    f"Tool-use loop hit cap of {self._max_iters} iterations.")
+        except Exception as exc:  # noqa: BLE001
+            self.SIG_ERROR.emit(f"{type(exc).__name__}: {exc}")
+        finally:
+            self.SIG_DONE.emit()
+
+
+class ChatClient(QtCore.QObject):
+    """Public-facing chat client. Owns the worker thread and tool runner.
+
+    The worker thread is started lazily on the first ``send()`` so a misbehaving
+    plugin init can't strand a thread."""
+
+    SIG_ASSISTANT_TEXT = QtCore.Signal(str)
+    SIG_TOOL_CALL = QtCore.Signal(str, object)
+    SIG_TOOL_RESULT = QtCore.Signal(str, str, bool)
+    SIG_DONE = QtCore.Signal()
+    SIG_ERROR = QtCore.Signal(str)
+
+    _SIG_SEND = QtCore.Signal(str)
+    _SIG_CONFIGURE = QtCore.Signal(object)
+    _SIG_RESET = QtCore.Signal()
+
+    def __init__(self, rpa, api_key=None, model=DEFAULT_MODEL,
+                 max_iters=DEFAULT_MAX_TOOL_ITERATIONS, parent=None):
+        log("ChatClient.__init__ start")
+        super().__init__(parent)
+        self._rpa = rpa
+        self._api_key = api_key or ""
+        self._model = model
+        self._max_iters = max_iters
+        try:
+            log("building RPA tool schemas")
+            self._tools = tool_bridge.build_tools(rpa)
+            log(f"built {len(self._tools)} tool schemas")
+        except Exception as exc:  # noqa: BLE001
+            log_exc("tool_bridge.build_tools failed")
+            self._tools = []
+            self._tool_build_error = str(exc)
+        else:
+            self._tool_build_error = ""
+
+        try:
+            log("constructing _ToolRunner")
+            self._tool_runner = _ToolRunner(rpa, parent=self)
+            log("constructing QThread + _ChatWorker")
+            self._thread = QtCore.QThread(self)
+            self._worker = _ChatWorker(self._tool_runner)
+            self._worker.moveToThread(self._thread)
+            log("worker moved to thread")
+        except Exception:
+            log_exc("FATAL: thread/worker setup failed")
+            raise
+
+        try:
+            self._SIG_SEND.connect(self._worker.send)
+            self._SIG_CONFIGURE.connect(self._worker.configure)
+            self._SIG_RESET.connect(self._worker.reset)
+            self._cancel_proxy = self._worker.cancel
+            self._worker.SIG_ASSISTANT_TEXT.connect(self.SIG_ASSISTANT_TEXT)
+            self._worker.SIG_TOOL_CALL.connect(self.SIG_TOOL_CALL)
+            self._worker.SIG_TOOL_RESULT.connect(self.SIG_TOOL_RESULT)
+            self._worker.SIG_DONE.connect(self.SIG_DONE)
+            self._worker.SIG_ERROR.connect(self.SIG_ERROR)
+            log("ChatClient signals wired")
+        except Exception:
+            log_exc("FATAL: ChatClient signal wiring failed")
+            raise
+        log("ChatClient.__init__ DONE")
+
+    def tool_count(self) -> int:
+        return len(self._tools)
+
+    def tool_build_error(self) -> str:
+        return self._tool_build_error
+
+    def _ensure_thread(self):
+        if not self._thread.isRunning():
+            self._thread.start()
+
+    def _push_config(self):
+        self._SIG_CONFIGURE.emit({
+            "api_key": self._api_key,
+            "model": self._model,
+            "tools": self._tools,
+            "max_iters": self._max_iters,
+        })
+
+    def set_api_key(self, api_key):
+        self._api_key = api_key or ""
+        if self._thread.isRunning():
+            self._push_config()
+
+    def set_model(self, model):
+        self._model = model or DEFAULT_MODEL
+        if self._thread.isRunning():
+            self._push_config()
+
+    def send(self, user_text):
+        self._ensure_thread()
+        self._push_config()
+        self._SIG_SEND.emit(user_text)
+
+    def cancel(self):
+        # DirectConnection-equivalent: just flip the flag on the worker. The
+        # worker reads it between iterations.
+        self._cancel_proxy()
+
+    def reset(self):
+        self._SIG_RESET.emit()
+
+    def shutdown(self):
+        if self._thread.isRunning():
+            self._thread.quit()
+            self._thread.wait(2000)

--- a/rpa/plugins/ai_chat/widget/tool_bridge.py
+++ b/rpa/plugins/ai_chat/widget/tool_bridge.py
@@ -1,0 +1,182 @@
+"""
+Reflects RPA's public API modules into Anthropic tool schemas and dispatches
+tool calls back into the live RPA instance.
+
+Tool name format: ``<module>__<method>`` (double underscore, because Anthropic
+disallows ``.`` in tool names). Example: ``timeline_api__goto_frame``.
+"""
+import inspect
+import typing
+from typing import Any
+
+
+# RPA modules to expose. Mirrors the discovery list in
+# rpa_widgets/rpa_interpreter/rpa_interpreter.py.
+_RPA_MODULES = (
+    "session_api",
+    "annotation_api",
+    "timeline_api",
+    "color_api",
+    "viewport_api",
+)
+
+# Hard cap on the size of a tool_result payload sent back to the model.
+_MAX_RESULT_CHARS = 8000
+
+
+def _python_type_to_schema(py_type: Any) -> dict:
+    """Map a Python annotation to a JSON Schema fragment.
+
+    Falls back to a permissive multi-type schema for anything we cannot resolve,
+    so the model can still attempt the call rather than refusing because no
+    schema fits.
+    """
+    permissive = {"type": ["string", "number", "boolean", "object", "array", "null"]}
+    if py_type is inspect.Parameter.empty or py_type is Any:
+        return permissive
+
+    origin = typing.get_origin(py_type)
+    args = typing.get_args(py_type)
+
+    # Optional[X] / Union[X, None] -> use X's schema, mark nullable by adding "null".
+    if origin is typing.Union:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            inner = _python_type_to_schema(non_none[0])
+            t = inner.get("type")
+            if isinstance(t, str):
+                inner["type"] = [t, "null"]
+            elif isinstance(t, list) and "null" not in t:
+                inner["type"] = t + ["null"]
+            return inner
+        return permissive
+
+    if origin in (list, tuple, set, frozenset):
+        item_schema = _python_type_to_schema(args[0]) if args else {}
+        return {"type": "array", "items": item_schema or permissive}
+
+    if origin is dict:
+        return {"type": "object"}
+
+    if py_type is bool:
+        return {"type": "boolean"}
+    if py_type is int:
+        return {"type": "integer"}
+    if py_type is float:
+        return {"type": "number"}
+    if py_type is str:
+        return {"type": "string"}
+    if py_type is list:
+        return {"type": "array"}
+    if py_type is dict:
+        return {"type": "object"}
+    if py_type is type(None):
+        return {"type": "null"}
+
+    return permissive
+
+
+def _build_input_schema(method) -> dict:
+    """Build a JSON Schema object for ``method``'s parameters."""
+    properties: dict = {}
+    required: list = []
+    try:
+        sig = inspect.signature(method)
+    except (TypeError, ValueError):
+        return {"type": "object", "properties": {}, "additionalProperties": True}
+
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL,
+                          inspect.Parameter.VAR_KEYWORD):
+            continue
+        properties[name] = _python_type_to_schema(param.annotation)
+        if param.default is inspect.Parameter.empty:
+            required.append(name)
+
+    schema = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _short_description(method, fallback: str) -> str:
+    doc = inspect.getdoc(method)
+    if not doc:
+        return fallback
+    # First non-empty line.
+    for line in doc.splitlines():
+        line = line.strip()
+        if line:
+            # Anthropic enforces a length cap on descriptions; keep it short.
+            return line[:512]
+    return fallback
+
+
+def _is_signal(member) -> bool:
+    # Qt Signal instances live on the class as Signal/PyQtSignal descriptors.
+    # Be defensive about binding differences.
+    cls_name = type(member).__name__
+    if cls_name in ("Signal", "SignalInstance", "pyqtSignal", "pyqtBoundSignal"):
+        return True
+    return False
+
+
+def build_tools(rpa) -> list:
+    """Reflect every public method on each RPA API module as a tool schema.
+
+    Returns a list of dicts in Anthropic's ``tools`` parameter format.
+    """
+    tools: list = []
+    for module_name in _RPA_MODULES:
+        module = getattr(rpa, module_name, None)
+        if module is None:
+            continue
+        for attr_name in dir(module):
+            if attr_name.startswith("_"):
+                continue
+            if attr_name.startswith("SIG_"):
+                continue
+            if attr_name == "delegate_mngr":
+                continue
+            try:
+                member = getattr(module, attr_name)
+            except Exception:
+                continue
+            if _is_signal(member):
+                continue
+            if not callable(member):
+                continue
+
+            tool_name = f"{module_name}__{attr_name}"
+            description = _short_description(
+                member, fallback=f"{module_name}.{attr_name}")
+            tools.append({
+                "name": tool_name,
+                "description": description,
+                "input_schema": _build_input_schema(member),
+            })
+    return tools
+
+
+def call_tool(rpa, tool_name: str, args: dict) -> str:
+    """Dispatch a tool call into the RPA instance and return a string result.
+
+    Must be invoked on the Qt main thread (RPA is not thread-safe). Errors are
+    converted to strings; the caller is responsible for marking the
+    ``tool_result`` block with ``is_error=True``.
+    """
+    if "__" not in tool_name:
+        raise ValueError(f"malformed tool name: {tool_name!r}")
+    module_name, method_name = tool_name.split("__", 1)
+    if module_name not in _RPA_MODULES:
+        raise ValueError(f"unknown module: {module_name!r}")
+
+    module = getattr(rpa, module_name)
+    method = getattr(module, method_name)
+    result = method(**(args or {}))
+    text = repr(result)
+    if len(text) > _MAX_RESULT_CHARS:
+        text = text[:_MAX_RESULT_CHARS] + f"\n...[truncated, total {len(text)} chars]"
+    return text

--- a/rpa/plugins/app_session_manager/widget/clips_controller/clips_controller.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/clips_controller.py
@@ -279,6 +279,21 @@ class ClipsController(QtCore.QObject):
         self.__session_api.set_active_clips(self.__playlist, ids)
         self.__model.update_background_role()
 
+    def __read_sort_pref(self):
+        raw = self.__config_api.value(PrefKey.HEADER_SORT_BY.value, None)
+        if raw is None:
+            return None, None
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+            except (ValueError, TypeError):
+                return None, None
+        else:
+            parsed = raw
+        if isinstance(parsed, (list, tuple)) and len(parsed) == 2:
+            return parsed[0], parsed[1]
+        return None, None
+
     def load_preferences(self):
         self.__config_api.beginGroup(PrefKey.PLUGIN.value)
         pref_attrs = json.loads(
@@ -286,11 +301,8 @@ class ClipsController(QtCore.QObject):
         if PLAY_ORDER_ID not in pref_attrs:
             pref_attrs.insert(0, PLAY_ORDER_ID)
         self.__header_view_pref_cntrlr.set_attrs(pref_attrs)
-        sort_attr_id_value, order = self.__config_api.value(
-            PrefKey.HEADER_SORT_BY.value, [None, None])
-        if order:
-            order = QtCore.Qt.AscendingOrder if order == PrefKey.ASC.value \
-            else QtCore.Qt.DescendingOrder
+        # JSON round-trip: QSettings INI (Linux) mangles native-list values.
+        sort_attr_id_value, order = self.__read_sort_pref()
         self.__header_view_pref_cntrlr.set_sort_state(sort_attr_id_value, order)
         self.__header_view_pref_cntrlr.set_column_widths(
             json.loads(self.__config_api.value(
@@ -302,11 +314,12 @@ class ClipsController(QtCore.QObject):
         self.__config_api.setValue(
             PrefKey.HEADER_COLUMNS.value,
             json.dumps(self.__header_view_pref_cntrlr.get_attrs()))
-        sort_attr_id, order  = self.__header_view_pref_cntrlr.get_sort_state()
-        order = PrefKey.ASC.value if order == QtCore.Qt.AscendingOrder \
+        sort_attr_id, order = self.__header_view_pref_cntrlr.get_sort_state()
+        order_str = PrefKey.ASC.value if order == QtCore.Qt.AscendingOrder \
             else PrefKey.DESC.value
         self.__config_api.setValue(
-            PrefKey.HEADER_SORT_BY.value, [sort_attr_id, order])
+            PrefKey.HEADER_SORT_BY.value,
+            json.dumps([sort_attr_id, order_str]))
         self.__config_api.setValue(
             PrefKey.HEADER_COLUMN_WIDTHS.value,
             json.dumps(self.__header_view_pref_cntrlr.get_column_widths()))

--- a/rpa/plugins/app_session_manager/widget/clips_controller/view/header_view.py
+++ b/rpa/plugins/app_session_manager/widget/clips_controller/view/header_view.py
@@ -7,6 +7,26 @@ except:
 from app_session_manager.widget.clips_controller.view.model import THUMBNAIL_WIDTH
 
 
+def _to_sort_order(value):
+    """Coerce arbitrary input to a Qt.SortOrder enum.
+
+    QSettings on Linux (INI format) returns values as strings regardless of
+    what was stored, so downstream code must not assume enum identity is
+    preserved across a save/load round-trip.
+    """
+    if isinstance(value, QtCore.Qt.SortOrder):
+        return value
+    if value is None:
+        return QtCore.Qt.AscendingOrder
+    if isinstance(value, str):
+        return QtCore.Qt.DescendingOrder if value.lower().startswith("desc") \
+            else QtCore.Qt.AscendingOrder
+    if isinstance(value, int):
+        return QtCore.Qt.DescendingOrder if value == 1 \
+            else QtCore.Qt.AscendingOrder
+    return QtCore.Qt.AscendingOrder
+
+
 class ActionWithStrData(QAction):
     SIG_TRIGGERED = QtCore.Signal(str)
 
@@ -244,8 +264,11 @@ class HeaderViewPrefCntrlr:
         return [attr_pair[0] for attr_pair in visually_sorted_columns]
 
     def set_sort_state(self, attr, order):
-        if order is None:
-            order = QtCore.Qt.AscendingOrder
+        # Normalize `order` to Qt.SortOrder. PySide2 QSettings on Linux (INI
+        # format) round-trips values through text, so callers may hand us
+        # strings ("asc"/"desc"), ints (0/1), None, or the enum itself.
+        # PySide2's setSortIndicator rejects anything except Qt.SortOrder.
+        order = _to_sort_order(order)
 
         model_attrs = self.__source_model.attrs
         if any([not attr, attr not in model_attrs]):

--- a/rpa/plugins/open_app_plugins.cfg
+++ b/rpa/plugins/open_app_plugins.cfg
@@ -38,6 +38,7 @@ annotation
 # Help
 rpa_app_info_hub
 rpa_interpreter
+ai_chat
 session_tree_viewer
 help_menu
 app_console_logger

--- a/rpa/requirements.txt
+++ b/rpa/requirements.txt
@@ -1,3 +1,4 @@
 playwright
 scipy==1.11.4
 imageio
+anthropic>=0.40


### PR DESCRIPTION
## Summary

Three commits ahead of upstream/main:

- **Add ai_chat plugin: natural-language control of RPA via Claude** — Bundles a new Help-menu plugin exposing RPA's session/annotation/timeline/color/viewport APIs as Anthropic tool-use schemas. Includes a worker QThread, main-thread tool runner (queued signal + threading.Event), prompt caching, and model dropdown (Haiku 4.5 default, Sonnet 4.6, Opus 4.7). Settings persist in QSettings under `ai_chat/`; logs at `~/.rpa_app/ai_chat.log`.
- **Fix set_attr_value for session-only clip attrs** — Attrs like `comment` have no OpenRV node-side handler. Previously skipped entirely; now, if registered in session attrs metadata, the value is applied to RPA session-state clip.
- **Fix setSortIndicator crash on PySide2/Linux INI QSettings** — Store `HEADER_SORT_BY` as JSON (matches `HEADER_COLUMNS`); legacy list shape still readable. Normalize `order` to `Qt.SortOrder` inside `set_sort_state`.

## Test plan

- [ ] Launch app, open ai_chat panel from Help menu, send a message and confirm tool calls execute against RPA
- [ ] Switch model in dropdown and verify setting persists across restart
- [ ] Set a session-only clip attr (e.g. `comment`) via plugin and confirm value lands on the RPA clip
- [ ] On Linux/PySide2, change Session Manager sort column/order, restart app, confirm no crash and sort restored